### PR TITLE
Fix missing entity crashes

### DIFF
--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/entities/EntityBanshee.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/entities/EntityBanshee.java
@@ -478,20 +478,24 @@ public class EntityBanshee extends EntityMob implements IAggressive{
         {
             EntityLivingBase entitylivingbase = EntityBanshee.this.getAttackTarget();
 
-            if (EntityBanshee.this.getEntityBoundingBox().intersects(entitylivingbase.getEntityBoundingBox()))
-            {
-                EntityBanshee.this.attackEntityAsMob(entitylivingbase);
-            }
-            else
-            {
-                double d0 = EntityBanshee.this.getDistanceSq(entitylivingbase);
-
-                if (d0 < 9.0D)
+            if (entitylivingbase != null) {
+                if (EntityBanshee.this.getEntityBoundingBox().intersects(entitylivingbase.getEntityBoundingBox()))
                 {
-                    Vec3d vec3d = entitylivingbase.getPositionEyes(1.0F);
-                    EntityBanshee.this.moveHelper.setMoveTo(vec3d.x, vec3d.y, vec3d.z, 1.0D);
+                    EntityBanshee.this.attackEntityAsMob(entitylivingbase);
+                }
+                else
+                {
+                    double d0 = EntityBanshee.this.getDistanceSq(entitylivingbase);
+
+                    if (d0 < 9.0D)
+                    {
+                        Vec3d vec3d = entitylivingbase.getPositionEyes(1.0F);
+                        EntityBanshee.this.moveHelper.setMoveTo(vec3d.x, vec3d.y, vec3d.z, 1.0D);
+                    }
                 }
             }
+
+           super.updateTask();
         }
     }
     

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/entities/EntityUndeadSwine.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/entities/EntityUndeadSwine.java
@@ -250,32 +250,36 @@ public class EntityUndeadSwine extends EntityMob{
         public void updateTask() {
            --this.attackTime;
            EntityLivingBase entitylivingbase = this.blaze.getAttackTarget();
-           double d0 = this.blaze.getDistance(entitylivingbase);
-           if (d0 < 2.2D) {
-              if (this.attackTime <= 0) {
-                 this.attackTime = 30;
-                 this.blaze.attackEntityAsMob(entitylivingbase);
-              }
 
-           } else if (d0 < this.getFollowDistance() * this.getFollowDistance()) {
-              double v = 4.0D;
-        	  double d1 = v * (entitylivingbase.posX - this.blaze.posX)/d0;
-              double d2 = v * (entitylivingbase.posY - this.blaze.posY)/d0;
-              double d3 = v * (entitylivingbase.posZ - this.blaze.posZ)/d0;
-              if (this.attackTime <= 0) {
-                 ++this.attackStep;
-                 if (this.attackStep > 20) {
-                    this.blaze.moveHelper.setMoveTo(this.blaze.posX + d1, this.blaze.posY + d2, this.blaze.posZ + d3, 2.0D);
-                 } else if(this.attackStep > 100) {
-                	 this.attackTime = 60;
-                	 this.attackStep = 0;
-                 }
-              }
+           if (entitylivingbase != null) {
+               double d0 = this.blaze.getDistance(entitylivingbase);
 
-              this.blaze.getLookHelper().setLookPositionWithEntity(entitylivingbase, 100.0F, 100.0F);
-           } else {
-              this.blaze.getNavigator().clearPath();
-              this.blaze.getMoveHelper().setMoveTo(entitylivingbase.posX, entitylivingbase.posY, entitylivingbase.posZ, 1.0D);
+               if (d0 < 2.2D) {
+                  if (this.attackTime <= 0) {
+                     this.attackTime = 30;
+                     this.blaze.attackEntityAsMob(entitylivingbase);
+                  }
+
+               } else if (d0 < this.getFollowDistance() * this.getFollowDistance()) {
+                  double v = 4.0D;
+            	  double d1 = v * (entitylivingbase.posX - this.blaze.posX)/d0;
+                  double d2 = v * (entitylivingbase.posY - this.blaze.posY)/d0;
+                  double d3 = v * (entitylivingbase.posZ - this.blaze.posZ)/d0;
+                  if (this.attackTime <= 0) {
+                     ++this.attackStep;
+                     if (this.attackStep > 20) {
+                        this.blaze.moveHelper.setMoveTo(this.blaze.posX + d1, this.blaze.posY + d2, this.blaze.posZ + d3, 2.0D);
+                     } else if(this.attackStep > 100) {
+                    	 this.attackTime = 60;
+                    	 this.attackStep = 0;
+                     }
+                  }
+
+                  this.blaze.getLookHelper().setLookPositionWithEntity(entitylivingbase, 100.0F, 100.0F);
+               } else {
+                  this.blaze.getNavigator().clearPath();
+                  this.blaze.getMoveHelper().setMoveTo(entitylivingbase.posX, entitylivingbase.posY, entitylivingbase.posZ, 1.0D);
+               }
            }
 
            super.updateTask();

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/entities/ai/EntityFishAIAttackRange.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/entities/ai/EntityFishAIAttackRange.java
@@ -117,60 +117,63 @@ public class EntityFishAIAttackRange extends EntityAIBase {
     public void updateTask() {
        --this.attackTime;
        EntityLivingBase entitylivingbase = this.shooter.getAttackTarget();
-       double d0 = this.shooter.getDistanceSq(entitylivingbase);
-       if (d0 < (this.shooter.width + entitylivingbase.width) * (this.shooter.width + entitylivingbase.width)) {
-          if (this.attackTime <= 0) {
-             this.attackTime = 20;
-             this.shooter.attackEntityAsMob(entitylivingbase);
-          }
 
-          this.shooter.getMoveHelper().setMoveTo(entitylivingbase.posX, entitylivingbase.posY, entitylivingbase.posZ, 1.0D);
-       } else if (d0 < this.getFollowDistance() * this.getFollowDistance()) {
-          double d1 = entitylivingbase.posX - this.shooter.posX;
-          double d2 = entitylivingbase.getEntityBoundingBox().minY + (double)(entitylivingbase.height / 2.0F) - (this.shooter.posY + (double)(this.shooter.height / 2.0F));
-          double d3 = entitylivingbase.posZ - this.shooter.posZ;
-          if (this.attackTime <= 0) {
-             ++this.attackStep;
-             if (this.attackStep == 1) {
-                this.attackTime = 30;
-                if(this.shooter instanceof IAggressive && !this.shooter.isChild() && ((IAggressive) this.shooter).getAttackTimer() == 0.0F/* && !((EntitySalamander) this.shooter).isTamed()*/) {
-             	   ((IAggressive) this.shooter).setAttackTimer(80);
-                }
-             } else if (this.attackStep <= (this.shot_times + 1)) {
-                this.attackTime = 6;
-             } else {
-                this.attackTime = this.attackCD * 20;
-                this.attackStep = 0;
-             }
+       if (entitylivingbase != null) {
+           double d0 = this.shooter.getDistanceSq(entitylivingbase);
+           if (d0 < (this.shooter.width + entitylivingbase.width) * (this.shooter.width + entitylivingbase.width)) {
+              if (this.attackTime <= 0) {
+                 this.attackTime = 20;
+                 this.shooter.attackEntityAsMob(entitylivingbase);
+              }
 
-             if (this.attackStep > 1) {
-                float f = MathHelper.sqrt(MathHelper.sqrt(d0)) * 0.1F;
+              this.shooter.getMoveHelper().setMoveTo(entitylivingbase.posX, entitylivingbase.posY, entitylivingbase.posZ, 1.0D);
+           } else if (d0 < this.getFollowDistance() * this.getFollowDistance()) {
+              double d1 = entitylivingbase.posX - this.shooter.posX;
+              double d2 = entitylivingbase.getEntityBoundingBox().minY + (double)(entitylivingbase.height / 2.0F) - (this.shooter.posY + (double)(this.shooter.height / 2.0F));
+              double d3 = entitylivingbase.posZ - this.shooter.posZ;
+              if (this.attackTime <= 0) {
+                 ++this.attackStep;
+                 if (this.attackStep == 1) {
+                    this.attackTime = 30;
+                    if(this.shooter instanceof IAggressive && !this.shooter.isChild() && ((IAggressive) this.shooter).getAttackTimer() == 0.0F/* && !((EntitySalamander) this.shooter).isTamed()*/) {
+                 	   ((IAggressive) this.shooter).setAttackTimer(80);
+                    }
+                 } else if (this.attackStep <= (this.shot_times + 1)) {
+                    this.attackTime = 6;
+                 } else {
+                    this.attackTime = this.attackCD * 20;
+                    this.attackStep = 0;
+                 }
 
-                this.shooter.playSound(this.sound, 1.0F, 1.0F);
-                double t1 = d1 + this.shooter.getRNG().nextGaussian() * (double)f;
-                double t2 = d2 + (this.curve * d0 / 64.0D);
-                double t3 = d3 + this.shooter.getRNG().nextGaussian() * (double)f;
-                double t4 = (double)MathHelper.sqrt(t1 * t1 + t2 * t2 + t3 * t3);                
-                Entity shotentity = EntityList.newEntity(this.shot, this.shooter.getEntityWorld());
-                ((EntityFireball)shotentity).shootingEntity = this.shooter;
-                shotentity.setLocationAndAngles(this.shooter.posX + (d1 / t4 * Xoffset), this.shooter.posY + (double)(this.shooter.height / 2.0F) + Yoffset, this.shooter.posZ + (d3 / t4 * Zoffset), this.shooter.rotationYaw, this.shooter.rotationPitch);
-                ((EntityFireball)shotentity).motionX = (t1 / t4) * 0.75D;
-                ((EntityFireball)shotentity).motionY = (t2 / t4) * 0.75D;
-                ((EntityFireball)shotentity).motionZ = (t3 / t4) * 0.75D;
-                this.shooter.world.spawnEntity(shotentity);
-                
-                if(this.shooter instanceof EntityBoneWorm && ((EntityBoneWorm)this.shooter).attackTimer[0] == 0) {
-                	((EntityBoneWorm)this.shooter).attackTimer[0] = 15;
-                	this.shooter.world.setEntityState(this.shooter, (byte)4);
-                	((EntityBoneWorm)this.shooter).setRunning(200);
-                }
-             }
-          }
+                 if (this.attackStep > 1) {
+                    float f = MathHelper.sqrt(MathHelper.sqrt(d0)) * 0.1F;
 
-          this.shooter.getLookHelper().setLookPositionWithEntity(entitylivingbase, 10.0F, 10.0F);
-       } else {
-          this.shooter.getNavigator().clearPath();
-          this.shooter.getMoveHelper().setMoveTo(entitylivingbase.posX, entitylivingbase.posY, entitylivingbase.posZ, this.shooter.getMoveHelper().getSpeed());
+                    this.shooter.playSound(this.sound, 1.0F, 1.0F);
+                    double t1 = d1 + this.shooter.getRNG().nextGaussian() * (double)f;
+                    double t2 = d2 + (this.curve * d0 / 64.0D);
+                    double t3 = d3 + this.shooter.getRNG().nextGaussian() * (double)f;
+                    double t4 = (double)MathHelper.sqrt(t1 * t1 + t2 * t2 + t3 * t3);                
+                    Entity shotentity = EntityList.newEntity(this.shot, this.shooter.getEntityWorld());
+                    ((EntityFireball)shotentity).shootingEntity = this.shooter;
+                    shotentity.setLocationAndAngles(this.shooter.posX + (d1 / t4 * Xoffset), this.shooter.posY + (double)(this.shooter.height / 2.0F) + Yoffset, this.shooter.posZ + (d3 / t4 * Zoffset), this.shooter.rotationYaw, this.shooter.rotationPitch);
+                    ((EntityFireball)shotentity).motionX = (t1 / t4) * 0.75D;
+                    ((EntityFireball)shotentity).motionY = (t2 / t4) * 0.75D;
+                    ((EntityFireball)shotentity).motionZ = (t3 / t4) * 0.75D;
+                    this.shooter.world.spawnEntity(shotentity);
+                    
+                    if(this.shooter instanceof EntityBoneWorm && ((EntityBoneWorm)this.shooter).attackTimer[0] == 0) {
+                    	((EntityBoneWorm)this.shooter).attackTimer[0] = 15;
+                    	this.shooter.world.setEntityState(this.shooter, (byte)4);
+                    	((EntityBoneWorm)this.shooter).setRunning(200);
+                    }
+                 }
+              }
+
+              this.shooter.getLookHelper().setLookPositionWithEntity(entitylivingbase, 10.0F, 10.0F);
+           } else {
+              this.shooter.getNavigator().clearPath();
+              this.shooter.getMoveHelper().setMoveTo(entitylivingbase.posX, entitylivingbase.posY, entitylivingbase.posZ, this.shooter.getMoveHelper().getSpeed());
+           }
        }
 
        super.updateTask();


### PR DESCRIPTION
- Added checks to prevent an attack target from being referenced if it's null

In some cases like in issue #63, a mob's attack target can be referenced even if it's null. This should fix that problem with a simple conditional.