### PR TITLE
Fix flying mob passenger collision and movement

### DIFF
--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/entities/flying/EntityPtera.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/entities/flying/EntityPtera.java
@@ -36,6 +36,16 @@ public class EntityPtera extends EntityFlyingMob {
 		super(worldIn);
 		this.setSize(1.6F, 0.8F);
 	}
+
+    @Override
+    public boolean canBeSteered() {
+        return false;
+    }
+
+    @Override
+    public boolean canPassengerSteer() {
+        return false;
+    }
 	
 	@Override
 	protected void initEntityAI() {


### PR DESCRIPTION
- Added checks for the passenger entity's bounding box
- Prevent passenger mobs from messing up Ptera's movement

Because there was no check in-place for the passenger mob's collision - and because passenger mobs were able to steer Pteras - they would often clip into the ground and suffocate themselves like in issue #38.

Edit:
It appears that the mobs can still move themselves into the ground. I'll keep looking into why this is and push some more commits to my branch.

Edit:
I've placed the issue on the riding mob's pathfinding tasks. I'll be pushing some potential fixes soon.