### PR TITLE
Add Quark compatibility for mimics

### DIFF
--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/client/Modconfig.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/client/Modconfig.java
@@ -156,6 +156,7 @@ public class Modconfig {
 	public static int Undertaker_Shovel_Cooldown;
 	public static int BoneWorm_DropHeart;
 	public static boolean Tinkers_Compat;
+	public static boolean Quark_Compat;
 	public static boolean SunScreen_Mode;
 	public static int SpawnRate_Cemetery;
 	public static int BoneSword_DamageCap;
@@ -365,8 +366,9 @@ public class Modconfig {
 		
 		SludgeWand_Cooldown = config.get(Configuration.CATEGORY_GENERAL, "pestilence cooldown", 60, "Ability cooldown of \"Pestilence\" [1-10000]", 1, 10000).getInt(60);
 		Undertaker_Shovel_Cooldown = config.get(Configuration.CATEGORY_GENERAL, "midnight mourne cooldown", 60, "Ability cooldown of Midnight Mourne [1-10000]", 1, 10000).getInt(60);
-		
+
 		Tinkers_Compat = config.get(Configuration.CATEGORY_GENERAL, "tinkers compatibility", true, "Adding new materials to Tinkers Construct. [false/true]").getBoolean(true);
+		Quark_Compat = config.get(Configuration.CATEGORY_GENERAL, "quark compatibility", true, "Add additional content that works with Quark. [false/true]").getBoolean(true);
 		SunScreen_Mode = config.get(Configuration.CATEGORY_GENERAL, "sunscreen mode", false, "Mobs in this mod will not burn under daylight. [false/true]").getBoolean(false);
 		
 		SpawnRate_Cemetery = config.get(Configuration.CATEGORY_GENERAL, "cemetery spawn rate", 1000, "Spawn rate of Cemetery (higher number = less frequent) [1-10000]", 1, 10000).getInt(1000);

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/client/layer/LayerMimicChest.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/client/layer/LayerMimicChest.java
@@ -9,13 +9,6 @@ import java.util.ArrayList;
 
 public class LayerMimicChest implements LayerRenderer<EntityMimic> {
     private static final ResourceLocation TEXTURE_ENDER = new ResourceLocation("textures/entity/chest/ender.png");
-    // This texture pool method works for now, but if we start adding in more textures for chests it could cause
-    // problems (since the texture ID would remain the same but the list entries would change).
-    // If we eventually need to expand, maybe we can work out something with UUIDs?
-    // Oh well! Until we need more textures, this should work.
-    public static ArrayList<String> texturePool = new ArrayList<String>(Arrays.asList(
-            "textures/entity/chest/normal.png"
-    ));
     private final RenderMimic pigRenderer;
 
     public LayerMimicChest(RenderMimic pigRendererIn)
@@ -28,16 +21,16 @@ public class LayerMimicChest implements LayerRenderer<EntityMimic> {
         return false;
     }
 
-	@Override
-	public void doRenderLayer(EntityMimic entitylivingbaseIn, float limbSwing, float limbSwingAmount,
-			float partialTicks, float ageInTicks, float netHeadYaw, float headPitch, float scale) {
+    @Override
+    public void doRenderLayer(EntityMimic entitylivingbaseIn, float limbSwing, float limbSwingAmount,
+                              float partialTicks, float ageInTicks, float netHeadYaw, float headPitch, float scale) {
         if (entitylivingbaseIn.getSkin() == entitylivingbaseIn.getVoidSkin()) {
             this.pigRenderer.bindTexture(TEXTURE_ENDER);
         } else {
             String chestTexture = entitylivingbaseIn.getChestTexture();
 
             // In the event that compatibility is no longer enabled (or the mod was removed), we reset the chest texture.
-            if (!texturePool.contains(chestTexture)) {
+            if (!EntityMimic.TEXTURE_POOL.contains(chestTexture)) {
                 chestTexture = "minecraft:textures/entity/chest/normal.png";
             }
 
@@ -47,5 +40,5 @@ public class LayerMimicChest implements LayerRenderer<EntityMimic> {
         //this.pigModel.setModelAttributes(this.pigRenderer.getMainModel());
         //this.pigModel.render(entitylivingbaseIn, limbSwing, limbSwingAmount, ageInTicks, netHeadYaw, headPitch, scale);
         this.pigRenderer.getMainModel().render(entitylivingbaseIn, limbSwing, limbSwingAmount, ageInTicks, netHeadYaw, headPitch, scale);
-	}
+    }
 }

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/client/layer/LayerMimicChest.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/client/layer/LayerMimicChest.java
@@ -4,10 +4,18 @@ import com.Fishmod.mod_LavaCow.client.renders.RenderMimic;
 import com.Fishmod.mod_LavaCow.entities.tameable.EntityMimic;
 import net.minecraft.client.renderer.entity.layers.LayerRenderer;
 import net.minecraft.util.ResourceLocation;
+import java.util.Arrays;
+import java.util.ArrayList;
 
 public class LayerMimicChest implements LayerRenderer<EntityMimic> {
     private static final ResourceLocation TEXTURE_ENDER = new ResourceLocation("textures/entity/chest/ender.png");
-    private static final ResourceLocation TEXTURE_NORMAL = new ResourceLocation("textures/entity/chest/normal.png");
+    // This texture pool method works for now, but if we start adding in more textures for chests it could cause
+    // problems (since the texture ID would remain the same but the list entries would change).
+    // If we eventually need to expand, maybe we can work out something with UUIDs?
+    // Oh well! Until we need more textures, this should work.
+    public static ArrayList<ResourceLocation> texturePool = new ArrayList<ResourceLocation>(Arrays.asList(
+            new ResourceLocation("textures/entity/chest/normal.png")
+    ));
     private final RenderMimic pigRenderer;
 
     public LayerMimicChest(RenderMimic pigRendererIn)
@@ -23,10 +31,21 @@ public class LayerMimicChest implements LayerRenderer<EntityMimic> {
 	@Override
 	public void doRenderLayer(EntityMimic entitylivingbaseIn, float limbSwing, float limbSwingAmount,
 			float partialTicks, float ageInTicks, float netHeadYaw, float headPitch, float scale) {
+        if (entitylivingbaseIn.getSkin() == entitylivingbaseIn.getVoidSkin()) {
+            this.pigRenderer.bindTexture(TEXTURE_ENDER);
+        } else {
+            int chestTexture = entitylivingbaseIn.getChestTexture();
 
-            this.pigRenderer.bindTexture(entitylivingbaseIn.getSkin() == entitylivingbaseIn.getVoidSkin() ? TEXTURE_ENDER : TEXTURE_NORMAL);
-            //this.pigModel.setModelAttributes(this.pigRenderer.getMainModel());
-            //this.pigModel.render(entitylivingbaseIn, limbSwing, limbSwingAmount, ageInTicks, netHeadYaw, headPitch, scale);	
-            this.pigRenderer.getMainModel().render(entitylivingbaseIn, limbSwing, limbSwingAmount, ageInTicks, netHeadYaw, headPitch, scale);	
+            // In the event that Quark compatibility is no longer enabled (or the mod was removed), we reset the chest texture.
+            if (chestTexture >= texturePool.size()) {
+                chestTexture = 0;
+            }
+
+            this.pigRenderer.bindTexture(texturePool.get(chestTexture));
+        }
+        //this.pigRenderer.bindTexture(entitylivingbaseIn.getSkin() == entitylivingbaseIn.getVoidSkin() ? TEXTURE_ENDER : TEXTURE_NORMAL);
+        //this.pigModel.setModelAttributes(this.pigRenderer.getMainModel());
+        //this.pigModel.render(entitylivingbaseIn, limbSwing, limbSwingAmount, ageInTicks, netHeadYaw, headPitch, scale);
+        this.pigRenderer.getMainModel().render(entitylivingbaseIn, limbSwing, limbSwingAmount, ageInTicks, netHeadYaw, headPitch, scale);
 	}
 }

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/client/layer/LayerMimicChest.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/client/layer/LayerMimicChest.java
@@ -13,8 +13,8 @@ public class LayerMimicChest implements LayerRenderer<EntityMimic> {
     // problems (since the texture ID would remain the same but the list entries would change).
     // If we eventually need to expand, maybe we can work out something with UUIDs?
     // Oh well! Until we need more textures, this should work.
-    public static ArrayList<ResourceLocation> texturePool = new ArrayList<ResourceLocation>(Arrays.asList(
-            new ResourceLocation("textures/entity/chest/normal.png")
+    public static ArrayList<String> texturePool = new ArrayList<String>(Arrays.asList(
+            "textures/entity/chest/normal.png"
     ));
     private final RenderMimic pigRenderer;
 
@@ -34,14 +34,14 @@ public class LayerMimicChest implements LayerRenderer<EntityMimic> {
         if (entitylivingbaseIn.getSkin() == entitylivingbaseIn.getVoidSkin()) {
             this.pigRenderer.bindTexture(TEXTURE_ENDER);
         } else {
-            int chestTexture = entitylivingbaseIn.getChestTexture();
+            String chestTexture = entitylivingbaseIn.getChestTexture();
 
-            // In the event that Quark compatibility is no longer enabled (or the mod was removed), we reset the chest texture.
-            if (chestTexture >= texturePool.size()) {
-                chestTexture = 0;
+            // In the event that compatibility is no longer enabled (or the mod was removed), we reset the chest texture.
+            if (!texturePool.contains(chestTexture)) {
+                chestTexture = "minecraft:textures/entity/chest/normal.png";
             }
 
-            this.pigRenderer.bindTexture(texturePool.get(chestTexture));
+            this.pigRenderer.bindTexture(new ResourceLocation(chestTexture));
         }
         //this.pigRenderer.bindTexture(entitylivingbaseIn.getSkin() == entitylivingbaseIn.getVoidSkin() ? TEXTURE_ENDER : TEXTURE_NORMAL);
         //this.pigModel.setModelAttributes(this.pigRenderer.getMainModel());

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/compat/QuarkCompatBridge.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/compat/QuarkCompatBridge.java
@@ -1,0 +1,15 @@
+package com.Fishmod.mod_LavaCow.compat;
+
+import com.Fishmod.mod_LavaCow.client.Modconfig;
+import com.Fishmod.mod_LavaCow.compat.quark.QuarkCompat;
+import net.minecraftforge.fml.common.Loader;
+
+public class QuarkCompatBridge {
+    private static final String COMPAT_MOD_ID = "quark";
+
+    public static void loadQuarkCompat() {
+        if (Modconfig.Quark_Compat && Loader.isModLoaded(COMPAT_MOD_ID)) {
+            QuarkCompat.register();
+        }
+    }
+}

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/compat/quark/QuarkCompat.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/compat/quark/QuarkCompat.java
@@ -6,16 +6,16 @@ import java.util.ArrayList;
 import java.util.Arrays;
 
 public class QuarkCompat {
-	private static boolean registered = false;
-	private static final ResourceLocation[] QUARK_TEXTURES = {
-            new ResourceLocation("quark:textures/blocks/chests/acacia.png"),
-            new ResourceLocation("quark:textures/blocks/chests/birch.png"),
-            new ResourceLocation("quark:textures/blocks/chests/dark_oak.png"),
-            new ResourceLocation("quark:textures/blocks/chests/jungle.png"),
-            new ResourceLocation("quark:textures/blocks/chests/spruce.png")
+    private static boolean registered = false;
+    private static final String[] QUARK_TEXTURES = {
+            "quark:textures/blocks/chests/acacia.png",
+            "quark:textures/blocks/chests/birch.png",
+            "quark:textures/blocks/chests/dark_oak.png",
+            "quark:textures/blocks/chests/jungle.png",
+            "quark:textures/blocks/chests/spruce.png"
     };
 
-	public static void register() {
+    public static void register() {
         if (!registered) {
             registered = true;
             init();
@@ -23,12 +23,12 @@ public class QuarkCompat {
             throw new RuntimeException("You can only call QuarkCompat.register() once");
         }
     }
-	
-	private static void init() {
-        addQuarkMimics();
-	}
 
-	private static void addQuarkMimics() {
-        LayerMimicChest.texturePool.addAll(new ArrayList<ResourceLocation>(Arrays.asList(QUARK_TEXTURES)));
+    private static void init() {
+        addQuarkMimics();
+    }
+
+    private static void addQuarkMimics() {
+        LayerMimicChest.texturePool.addAll(new ArrayList<String>(Arrays.asList(QUARK_TEXTURES)));
     }
 }

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/compat/quark/QuarkCompat.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/compat/quark/QuarkCompat.java
@@ -1,7 +1,6 @@
 package com.Fishmod.mod_LavaCow.compat.quark;
 
-import com.Fishmod.mod_LavaCow.client.layer.LayerMimicChest;
-import net.minecraft.util.ResourceLocation;
+import com.Fishmod.mod_LavaCow.entities.tameable.EntityMimic;
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -29,6 +28,6 @@ public class QuarkCompat {
     }
 
     private static void addQuarkMimics() {
-        LayerMimicChest.texturePool.addAll(new ArrayList<String>(Arrays.asList(QUARK_TEXTURES)));
+        EntityMimic.TEXTURE_POOL.addAll(new ArrayList<String>(Arrays.asList(QUARK_TEXTURES)));
     }
 }

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/compat/quark/QuarkCompat.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/compat/quark/QuarkCompat.java
@@ -1,0 +1,34 @@
+package com.Fishmod.mod_LavaCow.compat.quark;
+
+import com.Fishmod.mod_LavaCow.client.layer.LayerMimicChest;
+import net.minecraft.util.ResourceLocation;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public class QuarkCompat {
+	private static boolean registered = false;
+	private static final ResourceLocation[] QUARK_TEXTURES = {
+            new ResourceLocation("quark:textures/blocks/chests/acacia.png"),
+            new ResourceLocation("quark:textures/blocks/chests/birch.png"),
+            new ResourceLocation("quark:textures/blocks/chests/dark_oak.png"),
+            new ResourceLocation("quark:textures/blocks/chests/jungle.png"),
+            new ResourceLocation("quark:textures/blocks/chests/spruce.png")
+    };
+
+	public static void register() {
+        if (!registered) {
+            registered = true;
+            init();
+        } else {
+            throw new RuntimeException("You can only call QuarkCompat.register() once");
+        }
+    }
+	
+	private static void init() {
+        addQuarkMimics();
+	}
+
+	private static void addQuarkMimics() {
+        LayerMimicChest.texturePool.addAll(new ArrayList<ResourceLocation>(Arrays.asList(QUARK_TEXTURES)));
+    }
+}

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/entities/tameable/EntityMimic.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/entities/tameable/EntityMimic.java
@@ -58,9 +58,10 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class EntityMimic extends EntityFishTameable{
 	private static final DataParameter<Integer> SKIN_TYPE = EntityDataManager.<Integer>createKey(EntityMimic.class, DataSerializers.VARINT);
-    private static final DataParameter<Integer> CHEST_TEXTURE = EntityDataManager.<Integer>createKey(EntityMimic.class, DataSerializers.VARINT);
+    private static final DataParameter<String> CHEST_TEXTURE = EntityDataManager.<String>createKey(EntityMimic.class, DataSerializers.STRING);
 
-	private boolean isAggressive = false;
+
+    private boolean isAggressive = false;
 	private int AttackTimer = 40;
 	public NonNullList<ItemStack> inventory;
 	
@@ -94,7 +95,7 @@ public class EntityMimic extends EntityFishTameable{
     protected void entityInit() {
         super.entityInit();
         this.getDataManager().register(SKIN_TYPE, (4 + this.rand.nextInt(5)) % 6);
-        this.getDataManager().register(CHEST_TEXTURE, this.rand.nextInt(LayerMimicChest.texturePool.size()));
+        this.getDataManager().register(CHEST_TEXTURE, LayerMimicChest.texturePool.get(this.rand.nextInt(LayerMimicChest.texturePool.size())));
      }
 
     protected void applyEntityAttributes()
@@ -476,12 +477,12 @@ public class EntityMimic extends EntityFishTameable{
         	}
     }
 
-    public int getChestTexture()
+    public String getChestTexture()
     {
         return this.dataManager.get(CHEST_TEXTURE);
     }
 
-    public void setChestTexture(int chestTexture)
+    public void setChestTexture(String chestTexture)
     {
         this.dataManager.set(CHEST_TEXTURE, chestTexture);
     }
@@ -538,7 +539,7 @@ public class EntityMimic extends EntityFishTameable{
 		if (compound.hasKey("Items"))
 			ItemStackHelper.loadAllItems(compound, inventory);
 		this.setSkin(compound.getInteger("Variant"));
-		this.setChestTexture(compound.getInteger("Chest"));
+		this.setChestTexture(compound.getString("Chest"));
     }
 
 	@Override
@@ -546,7 +547,7 @@ public class EntityMimic extends EntityFishTameable{
 		super.writeEntityToNBT(compound);
 		ItemStackHelper.saveAllItems(compound, inventory, false);
         compound.setInteger("Variant", getSkin());
-        compound.setInteger("Chest", getChestTexture());
+        compound.setString("Chest", getChestTexture());
 	}
     
     @Override

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/entities/tameable/EntityMimic.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/entities/tameable/EntityMimic.java
@@ -4,6 +4,7 @@ import java.util.Random;
 import java.util.UUID;
 import javax.annotation.Nullable;
 
+import com.Fishmod.mod_LavaCow.client.layer.LayerMimicChest;
 import com.Fishmod.mod_LavaCow.client.Modconfig;
 import com.Fishmod.mod_LavaCow.core.SpawnUtil;
 import com.Fishmod.mod_LavaCow.init.FishItems;
@@ -57,6 +58,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class EntityMimic extends EntityFishTameable{
 	private static final DataParameter<Integer> SKIN_TYPE = EntityDataManager.<Integer>createKey(EntityMimic.class, DataSerializers.VARINT);
+    private static final DataParameter<Integer> CHEST_TEXTURE = EntityDataManager.<Integer>createKey(EntityMimic.class, DataSerializers.VARINT);
 
 	private boolean isAggressive = false;
 	private int AttackTimer = 40;
@@ -91,9 +93,10 @@ public class EntityMimic extends EntityFishTameable{
     
     protected void entityInit() {
         super.entityInit();
-        this.getDataManager().register(SKIN_TYPE, Integer.valueOf((4 + this.rand.nextInt(5)) % 6));
+        this.getDataManager().register(SKIN_TYPE, (4 + this.rand.nextInt(5)) % 6);
+        this.getDataManager().register(CHEST_TEXTURE, this.rand.nextInt(LayerMimicChest.texturePool.size()));
      }
-    
+
     protected void applyEntityAttributes()
     {
         super.applyEntityAttributes();
@@ -472,15 +475,25 @@ public class EntityMimic extends EntityFishTameable{
         		this.world.setEntityState(this, (byte)34);
         	}
     }
-    
+
+    public int getChestTexture()
+    {
+        return this.dataManager.get(CHEST_TEXTURE);
+    }
+
+    public void setChestTexture(int chestTexture)
+    {
+        this.dataManager.set(CHEST_TEXTURE, chestTexture);
+    }
+
     public int getSkin()
     {
-        return ((Integer)this.dataManager.get(SKIN_TYPE)).intValue();
+        return this.dataManager.get(SKIN_TYPE);
     }
 
     public void setSkin(int skinType)
     {
-        this.dataManager.set(SKIN_TYPE, Integer.valueOf(skinType));
+        this.dataManager.set(SKIN_TYPE, skinType);
     }
 	
 	public int getVoidSkin() {
@@ -525,13 +538,15 @@ public class EntityMimic extends EntityFishTameable{
 		if (compound.hasKey("Items"))
 			ItemStackHelper.loadAllItems(compound, inventory);
 		this.setSkin(compound.getInteger("Variant"));
-	}
+		this.setChestTexture(compound.getInteger("Chest"));
+    }
 
 	@Override
 	public void writeEntityToNBT(NBTTagCompound compound) {
 		super.writeEntityToNBT(compound);
 		ItemStackHelper.saveAllItems(compound, inventory, false);
-		compound.setInteger("Variant", getSkin());
+        compound.setInteger("Variant", getSkin());
+        compound.setInteger("Chest", getChestTexture());
 	}
     
     @Override

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/entities/tameable/EntityMimic.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/entities/tameable/EntityMimic.java
@@ -4,7 +4,6 @@ import java.util.Random;
 import java.util.UUID;
 import javax.annotation.Nullable;
 
-import com.Fishmod.mod_LavaCow.client.layer.LayerMimicChest;
 import com.Fishmod.mod_LavaCow.client.Modconfig;
 import com.Fishmod.mod_LavaCow.core.SpawnUtil;
 import com.Fishmod.mod_LavaCow.init.FishItems;
@@ -55,11 +54,15 @@ import net.minecraftforge.common.BiomeDictionary;
 import net.minecraftforge.common.BiomeDictionary.Type;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import java.util.Arrays;
+import java.util.ArrayList;
 
 public class EntityMimic extends EntityFishTameable{
 	private static final DataParameter<Integer> SKIN_TYPE = EntityDataManager.<Integer>createKey(EntityMimic.class, DataSerializers.VARINT);
     private static final DataParameter<String> CHEST_TEXTURE = EntityDataManager.<String>createKey(EntityMimic.class, DataSerializers.STRING);
-
+    public static ArrayList<String> TEXTURE_POOL = new ArrayList<String>(Arrays.asList(
+            "textures/entity/chest/normal.png"
+    ));
 
     private boolean isAggressive = false;
 	private int AttackTimer = 40;
@@ -95,7 +98,7 @@ public class EntityMimic extends EntityFishTameable{
     protected void entityInit() {
         super.entityInit();
         this.getDataManager().register(SKIN_TYPE, (4 + this.rand.nextInt(5)) % 6);
-        this.getDataManager().register(CHEST_TEXTURE, LayerMimicChest.texturePool.get(this.rand.nextInt(LayerMimicChest.texturePool.size())));
+        this.getDataManager().register(CHEST_TEXTURE, EntityMimic.TEXTURE_POOL.get(this.rand.nextInt(EntityMimic.TEXTURE_POOL.size())));
      }
 
     protected void applyEntityAttributes()

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/mod_LavaCow.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/mod_LavaCow.java
@@ -4,6 +4,7 @@ import org.apache.logging.log4j.Logger;
 
 import com.Fishmod.mod_LavaCow.client.Modconfig;
 import com.Fishmod.mod_LavaCow.compat.TinkersCompatBridge;
+import com.Fishmod.mod_LavaCow.compat.QuarkCompatBridge;
 import com.Fishmod.mod_LavaCow.init.AddRecipes;
 import com.Fishmod.mod_LavaCow.message.PacketMountSpecial;
 import com.Fishmod.mod_LavaCow.proxy.IProxy;
@@ -62,6 +63,7 @@ public class mod_LavaCow {
         PROXY.registerItemAndBlockRenderers();
         
         TinkersCompatBridge.loadTinkersCompat();
+        QuarkCompatBridge.loadQuarkCompat();
         PROXY.preInit(event);
         
         NETWORK_WRAPPER = NetworkRegistry.INSTANCE.newSimpleChannel(mod_LavaCow.MODID);


### PR DESCRIPTION
- Changed the mimic's chest rendering layer to use a dynamic texture pool
- Added a configuration option to toggle Quark compatibility

This should allow mimics to use the new chest textures from Quark. Optionally, it can also be disabled in the configuration.