### PR TITLE
Adjust grenade weight and remove needless entity

### DIFF
--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/entities/projectiles/EntityGhostBomb.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/entities/projectiles/EntityGhostBomb.java
@@ -1,10 +1,8 @@
 package com.Fishmod.mod_LavaCow.entities.projectiles;
 
-import com.Fishmod.mod_LavaCow.entities.EntityFoglet;
 import com.Fishmod.mod_LavaCow.init.FishItems;
 
 import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.projectile.EntityThrowable;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.math.BlockPos;
@@ -12,7 +10,7 @@ import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
 
 public class EntityGhostBomb extends EntityThrowable {
-	
+
     public EntityGhostBomb(World worldIn)
     {
         super(worldIn);
@@ -37,14 +35,11 @@ public class EntityGhostBomb extends EntityThrowable {
     }
 
 	@Override
-	protected void onImpact(RayTraceResult result) { 	
+	protected void onImpact(RayTraceResult result) {
         if (!this.world.isRemote)
         {
-        	EntityFoglet Dummy = new EntityFoglet(this.world);
-        	Dummy.setCustomNameTag("Ghost Bomb");
-        	this.world.createExplosion(Dummy, this.posX, this.posY, this.posZ, 4.0F, false);
-        	Dummy.setDead();
-        	this.world.playSound((EntityPlayer)null, new BlockPos(this.posX, this.posY, this.posZ), FishItems.ENTITY_BANSHEE_HURT, SoundCategory.BLOCKS, 1.0F, (this.rand.nextFloat() - this.rand.nextFloat()) * 0.2F + 1.0F);       	
+        	this.world.createExplosion(null, this.posX, this.posY, this.posZ, 4.0F, false);
+        	this.world.playSound(null, new BlockPos(this.posX, this.posY, this.posZ), FishItems.ENTITY_BANSHEE_HURT, SoundCategory.BLOCKS, 1.0F, (this.rand.nextFloat() - this.rand.nextFloat()) * 0.2F + 1.0F);
         	this.setDead();
         }
 	}

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/entities/projectiles/EntityHolyGrenade.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/entities/projectiles/EntityHolyGrenade.java
@@ -33,18 +33,15 @@ public class EntityHolyGrenade extends EntityThrowable {
      */
     protected float getGravityVelocity()
     {
-        return 0.01F;
+        return 0.075F;
     }
 
 	@Override
 	protected void onImpact(RayTraceResult result) {	
         if (!this.world.isRemote)
         {
-        	EntityFoglet Dummy = new EntityFoglet(this.world);
-        	Dummy.setCustomNameTag("Holy Grenade");
-        	this.world.createExplosion(Dummy, this.posX, this.posY, this.posZ, 4.0F, false);
-        	Dummy.setDead();
-        	this.world.playSound((EntityPlayer)null, new BlockPos(this.posX, this.posY, this.posZ), SoundEvents.ENTITY_GENERIC_EXPLODE, SoundCategory.BLOCKS, 1.0F, (this.rand.nextFloat() - this.rand.nextFloat()) * 0.2F + 1.0F);         	
+        	this.world.createExplosion(null, this.posX, this.posY, this.posZ, 4.0F, false);
+        	this.world.playSound(null, new BlockPos(this.posX, this.posY, this.posZ), SoundEvents.ENTITY_GENERIC_EXPLODE, SoundCategory.BLOCKS, 1.0F, (this.rand.nextFloat() - this.rand.nextFloat()) * 0.2F + 1.0F);
         	this.setDead();
         }
 	}

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/entities/projectiles/EntitySonicBomb.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/entities/projectiles/EntitySonicBomb.java
@@ -40,18 +40,15 @@ public class EntitySonicBomb extends EntityThrowable {
      */
     protected float getGravityVelocity()
     {
-        return 0.01F;
+        return 0.075F;
     }
 
 	@Override
 	protected void onImpact(RayTraceResult result) {	
         if (!this.world.isRemote)
         {
-        	EntityFoglet Dummy = new EntityFoglet(this.world);
-        	Dummy.setCustomNameTag("Sonic Bomb");
-        	this.world.createExplosion(Dummy, this.posX, this.posY, this.posZ, 4.0F, false);
-        	Dummy.setDead();
-        	this.world.playSound((EntityPlayer)null, new BlockPos(this.posX, this.posY, this.posZ), FishItems.ENTITY_BANSHEE_ATTACK, SoundCategory.BLOCKS, 1.0F, (this.rand.nextFloat() - this.rand.nextFloat()) * 0.2F + 1.0F);        	       	
+        	this.world.createExplosion(null, this.posX, this.posY, this.posZ, 4.0F, false);
+        	this.world.playSound(null, new BlockPos(this.posX, this.posY, this.posZ), FishItems.ENTITY_BANSHEE_ATTACK, SoundCategory.BLOCKS, 1.0F, (this.rand.nextFloat() - this.rand.nextFloat()) * 0.2F + 1.0F);
         	this.setDead();
         }
 	}

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/item/ItemHolyGrenade.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/item/ItemHolyGrenade.java
@@ -40,7 +40,7 @@ public class ItemHolyGrenade extends ItemFishCustom{
         {
         	if(itemstack.getItem().equals(FishItems.HOLY_GRENADE)) {
 	        	EntityHolyGrenade entitysnowball = new EntityHolyGrenade(worldIn, playerIn);
-	            entitysnowball.shoot(playerIn, playerIn.rotationPitch, playerIn.rotationYaw, -20.0F, 0.5F, 1.0F);
+	            entitysnowball.shoot(playerIn, playerIn.rotationPitch, playerIn.rotationYaw, -20.0F, 1.5F, 1.0F);
 	            worldIn.spawnEntity(entitysnowball);
         	}
         	else if(itemstack.getItem().equals(FishItems.GHOSTBOMB)) {
@@ -50,7 +50,7 @@ public class ItemHolyGrenade extends ItemFishCustom{
         	}
         	else if(itemstack.getItem().equals(FishItems.SONICBOMB)) {
 	        	EntitySonicBomb entitysnowball = new EntitySonicBomb(worldIn, playerIn);
-	            entitysnowball.shoot(playerIn, playerIn.rotationPitch, playerIn.rotationYaw, -20.0F, 0.5F, 1.0F);
+	            entitysnowball.shoot(playerIn, playerIn.rotationPitch, playerIn.rotationYaw, -20.0F, 1.5F, 1.0F);
 	            worldIn.spawnEntity(entitysnowball);
         	}
         }


### PR DESCRIPTION
- Adjusted the grenade weight to feel better when thrown
- Removed a needless entity which was being created during the explosion process

This is really a quality-of-life fix to address issue #25. It should feel more natural when grenades are thrown. An example of the adjusted weights can be seen here:

https://user-images.githubusercontent.com/7981517/104110928-2f7f8d00-52a2-11eb-94a6-25f2d2ac8ccf.mp4