### PR TITLE
Add raven, spectral raven, and seagull loot tables

### DIFF
--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/client/Modconfig.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/client/Modconfig.java
@@ -149,6 +149,7 @@ public class Modconfig {
 	public static int HaloNecklace_Damage;
 	public static String[] Intestine_lt = new String[0];
 	public static String[] Intestine_banlist = new String[0];
+	public static String[] Raven_Loot = new String[0];
 	public static int pScarecrow_PlagueDoctor;
 	public static String[] DreamCatcher_spawn = new String[0];
 	public static boolean Shattered_Ice;
@@ -333,7 +334,18 @@ public class Modconfig {
 					      		"minecraft:slime",
 					      		"minecraft:skeleton"},
 				"Customize the banlist for which mobs that intestines shouldn't drop from. Ex. \"minecraft:slime\" or \"mod_lavacow:vespa\"");
-		
+
+		Raven_Loot = config.getStringList("loot table for ravens", Configuration.CATEGORY_GENERAL,
+				new String[] {
+						"minecraft:beetroot_seeds,0.15",
+						"minecraft:wheat_seeds,0.15",
+						"minecraft:melon_seeds,0.15",
+						"minecraft:pumpkin_seeds,0.15",
+						"minecraft:gold_nugget,0.1",
+						"minecraft:iron_nugget,0.1"
+				},
+				"Customize the drop rates and the items which ravens can find. Ex. \"minecraft:slime_ball,0.4\" or \"mod_lavacow:sharptooth,0.1\"");
+
 		GoldenHeart_dur = config.get(Configuration.CATEGORY_GENERAL, "golden heart duribility", 250, "Set the duribility of Golden Heart, 0 = Infinite [0-10000]", 0, 10000).getInt(250);
 		GoldenHeart_bl = config.getStringList("banlisted items from golden heart", Configuration.CATEGORY_GENERAL, new String[0], "BlackBanlist for items that Golden Heart are unable to mend. Ex. \"minecraft:shears\" or \"mod_lavacow:moltenhammer\"");
 		

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/client/Modconfig.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/client/Modconfig.java
@@ -150,6 +150,8 @@ public class Modconfig {
 	public static String[] Intestine_lt = new String[0];
 	public static String[] Intestine_banlist = new String[0];
 	public static String[] Raven_Loot = new String[0];
+	public static String[] Seagull_Loot = new String[0];
+	public static String[] Spectral_Raven_Loot = new String[0];
 	public static int pScarecrow_PlagueDoctor;
 	public static String[] DreamCatcher_spawn = new String[0];
 	public static boolean Shattered_Ice;
@@ -338,13 +340,27 @@ public class Modconfig {
 		Raven_Loot = config.getStringList("loot table for ravens", Configuration.CATEGORY_GENERAL,
 				new String[] {
 						"minecraft:beetroot_seeds,0.15",
-						"minecraft:wheat_seeds,0.15",
+						"minecraft:wheat_seeds,0.15,2",
 						"minecraft:melon_seeds,0.15",
 						"minecraft:pumpkin_seeds,0.15",
-						"minecraft:gold_nugget,0.1",
-						"minecraft:iron_nugget,0.1"
+						"minecraft:gold_nugget,0.1,2",
+						"minecraft:iron_nugget,0.1,2"
 				},
-				"Customize the drop rates and the items which ravens can find. Ex. \"minecraft:slime_ball,0.4\" or \"mod_lavacow:sharptooth,0.1\"");
+				"Customize drop rates of the items which ravens can find. Ex. \"minecraft:fish@3,0.4,2\" or \"mod_lavacow:sharptooth,0.1\"");
+
+		Seagull_Loot = config.getStringList("loot table for seagulls", Configuration.CATEGORY_GENERAL,
+				new String[] {
+						"minecraft:fish@0,0.15",
+						"minecraft:fish@2,0.15"
+				},
+				"Customize drop rates of the items which seagulls can find. Ex. \"minecraft:fish@3,0.4,2\" or \"mod_lavacow:sharptooth,0.1\"");
+
+		Spectral_Raven_Loot = config.getStringList("loot table for spectral ravens", Configuration.CATEGORY_GENERAL,
+				new String[] {
+						"minecraft:gold_nugget,0.15,3",
+						"minecraft:iron_nugget,0.15,3"
+				},
+				"Customize drop rates of the items which spectral ravens can find. Ex. \"minecraft:fish@3,0.4,2\" or \"mod_lavacow:sharptooth,0.1\"");
 
 		GoldenHeart_dur = config.get(Configuration.CATEGORY_GENERAL, "golden heart duribility", 250, "Set the duribility of Golden Heart, 0 = Infinite [0-10000]", 0, 10000).getInt(250);
 		GoldenHeart_bl = config.getStringList("banlisted items from golden heart", Configuration.CATEGORY_GENERAL, new String[0], "BlackBanlist for items that Golden Heart are unable to mend. Ex. \"minecraft:shears\" or \"mod_lavacow:moltenhammer\"");

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/entities/tameable/EntityRaven.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/entities/tameable/EntityRaven.java
@@ -198,14 +198,25 @@ public class EntityRaven extends EntityFishTameable implements EntityFlying{
 	        }
 	        
 	    	if(!this.isSitting() && !this.isRiding() && this.getHeldItemMainhand().isEmpty() && this.ticksExisted % 200 == 0 && this.rand.nextFloat() < 0.02f) {
-	    	    Item chosenDrop = null;
+	    	    ItemStack chosenDrop = null;
+                Map<ItemStack, Float> lootTable;
 
-	    	    if (this.getSkin() != 2) {
-                    for(Map.Entry<Item, Float> entry : LootTableHandler.LOOT_RAVEN.entrySet()) {
-                        if (this.rand.nextFloat() < entry.getValue()) {
-                            chosenDrop = entry.getKey();
-                            break;
-                        }
+                switch (this.getSkin()) {
+                    case 2:
+                        lootTable = LootTableHandler.LOOT_SEAGULL;
+                        break;
+                    case 3:
+                        lootTable = LootTableHandler.LOOT_SPECTRAL_RAVEN;
+                        break;
+                    default:
+                        lootTable = LootTableHandler.LOOT_RAVEN;
+                        break;
+                }
+
+                for(Map.Entry<ItemStack, Float> entry : lootTable.entrySet()) {
+                    if (this.rand.nextFloat() < entry.getValue()) {
+                        chosenDrop = entry.getKey();
+                        break;
                     }
                 }
 
@@ -213,21 +224,21 @@ public class EntityRaven extends EntityFishTameable implements EntityFlying{
 	    	    if (chosenDrop == null) {
                     switch(this.getSkin()) {
                         case 1:
-                            chosenDrop = Items.IRON_NUGGET;
+                            chosenDrop = new ItemStack(Items.IRON_NUGGET, 1);
                             break;
                         case 2:
-                            chosenDrop = Items.FISH;
+                            chosenDrop = new ItemStack(Items.FISH, 1);
                             break;
                         case 3:
-                            chosenDrop = FishItems.ECTOPLASM;
+                            chosenDrop = new ItemStack(FishItems.ECTOPLASM, 1);
                             break;
                         default:
-                            chosenDrop = FishItems.FEATHER_BLACK;
+                            chosenDrop = new ItemStack(FishItems.FEATHER_BLACK, 1);
                             break;
                     }
                 }
 
-	    	    this.setHeldItem(getActiveHand(), new ItemStack(chosenDrop));
+	    	    this.setHeldItem(getActiveHand(), new ItemStack(chosenDrop.getItem(), this.rand.nextInt(chosenDrop.getCount()) + 1, chosenDrop.getMetadata()));
 	    	}
         }
         

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/entities/tameable/EntityRaven.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/entities/tameable/EntityRaven.java
@@ -1,5 +1,6 @@
 package com.Fishmod.mod_LavaCow.entities.tameable;
 
+import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 
@@ -9,6 +10,7 @@ import com.Fishmod.mod_LavaCow.client.Modconfig;
 import com.Fishmod.mod_LavaCow.core.SpawnUtil;
 import com.Fishmod.mod_LavaCow.entities.ai.EntityAITargetItem;
 import com.Fishmod.mod_LavaCow.init.FishItems;
+import com.Fishmod.mod_LavaCow.util.LootTableHandler;
 import com.google.common.collect.Sets;
 
 import net.minecraft.block.Block;
@@ -196,21 +198,36 @@ public class EntityRaven extends EntityFishTameable implements EntityFlying{
 	        }
 	        
 	    	if(!this.isSitting() && !this.isRiding() && this.getHeldItemMainhand().isEmpty() && this.ticksExisted % 200 == 0 && this.rand.nextFloat() < 0.02f) {
-	    		
-	    		switch(this.getSkin()) { 
-		            case 1: 
-		            	this.setHeldItem(getActiveHand(), new ItemStack(Items.IRON_NUGGET));
-		            	break; 
-		            case 2: 
-		            	this.setHeldItem(getActiveHand(), new ItemStack(Items.FISH, 1, 2));
-		                break; 
-		            case 3:
-		            	this.setHeldItem(getActiveHand(), new ItemStack(FishItems.ECTOPLASM));
-		                break;
-		            default: 
-		            	this.setHeldItem(getActiveHand(), new ItemStack(FishItems.FEATHER_BLACK));
-		                break;
-		        }
+	    	    Item chosenDrop = null;
+
+	    	    if (this.getSkin() != 2) {
+                    for(Map.Entry<Item, Float> entry : LootTableHandler.LOOT_RAVEN.entrySet()) {
+                        if (this.rand.nextFloat() < entry.getValue()) {
+                            chosenDrop = entry.getKey();
+                            break;
+                        }
+                    }
+                }
+
+	    	    // These are the fallback items in-case no special drop is chosen.
+	    	    if (chosenDrop == null) {
+                    switch(this.getSkin()) {
+                        case 1:
+                            chosenDrop = Items.IRON_NUGGET;
+                            break;
+                        case 2:
+                            chosenDrop = Items.FISH;
+                            break;
+                        case 3:
+                            chosenDrop = FishItems.ECTOPLASM;
+                            break;
+                        default:
+                            chosenDrop = FishItems.FEATHER_BLACK;
+                            break;
+                    }
+                }
+
+	    	    this.setHeldItem(getActiveHand(), new ItemStack(chosenDrop));
 	    	}
         }
         
@@ -527,12 +544,12 @@ public class EntityRaven extends EntityFishTameable implements EntityFlying{
     
     public int getSkin()
     {
-        return ((Integer)this.dataManager.get(SKIN_TYPE)).intValue();
+        return this.dataManager.get(SKIN_TYPE);
     }
 
     public void setSkin(int skinType)
     {
-        this.dataManager.set(SKIN_TYPE, Integer.valueOf(skinType));
+        this.dataManager.set(SKIN_TYPE, skinType);
     }
     
     private boolean isFetching() {
@@ -629,9 +646,9 @@ public class EntityRaven extends EntityFishTameable implements EntityFlying{
 	@Override
 	protected void dropFewItems(boolean recentlyHit, int looting) {
 		if (recentlyHit) {
-			int chance = rand.nextInt(3) + rand.nextInt(1 + looting);
-			for (int amount = 0; amount < chance; ++amount)
-				entityDropItem(new ItemStack(this.getSkin() == 2 ? Items.FEATHER : FishItems.FEATHER_BLACK), 0.0F);
+            int chance = rand.nextInt(3) + rand.nextInt(1 + looting);
+            for (int amount = 0; amount < chance; ++amount)
+                entityDropItem(new ItemStack(this.getSkin() == 2 ? Items.FEATHER : FishItems.FEATHER_BLACK), 0.0F);
 		}
 	}
 	

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/util/LootTableHandler.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/util/LootTableHandler.java
@@ -56,10 +56,39 @@ public class LootTableHandler {
 	public static ResourceLocation AVATON = null;
 	public static Map<Item, Integer> FISHABLE = new HashMap<Item, Integer>();
 	public static Map<ItemStack, Float> LOOT_INTESTINE = new HashMap<ItemStack, Float>();
-	public static Map<Item, Float> LOOT_RAVEN = new HashMap<Item, Float>();
+	public static Map<ItemStack, Float> LOOT_RAVEN = new HashMap<ItemStack, Float>();
+	public static Map<ItemStack, Float> LOOT_SEAGULL = new HashMap<ItemStack, Float>();
+	public static Map<ItemStack, Float> LOOT_SPECTRAL_RAVEN = new HashMap<ItemStack, Float>();
 	public static List<Biome.SpawnListEntry> DREAMCATCHER_LIST = Lists.<Biome.SpawnListEntry>newArrayList();
 	public static List<ResourceLocation> PARASITE_HOSTLIST = Lists.<ResourceLocation>newArrayList();
-	
+
+	public static Map<ItemStack, Float> parseLootTable(String[] lootTableConfiguration) {
+		Map<ItemStack, Float> lootTable = new HashMap<ItemStack, Float>();
+
+		for (String line : lootTableConfiguration) {
+			String[] lineSplit = line.split(",");
+			String[] nameSplit = lineSplit[0].split("@");
+			Item item = Item.getByNameOrId(nameSplit[0]);
+
+			if (item != null) {
+				int amount = 1;
+				int meta = 0;
+
+				if (lineSplit.length > 2) {
+					amount = Integer.parseInt(lineSplit[2]);
+				}
+
+				if (nameSplit.length > 1) {
+					meta = Integer.parseInt(nameSplit[1]);
+				}
+
+				lootTable.put(new ItemStack(item, amount, meta), Float.parseFloat(lineSplit[1]));
+			}
+		}
+
+		return lootTable;
+	}
+
 	public static void addLootTable()
 	{
 		//System.out.println("12OAOAOAOAOAOAOAOAOAOAOAO");
@@ -105,14 +134,10 @@ public class LootTableHandler {
 			}
 		}
 
-		for(String S : Modconfig.Raven_Loot) {
-			String[] S_splt = S.split(",");
-			Item item = Item.getByNameOrId(S_splt[0]);
-			if(item != null) {
-				LOOT_RAVEN.put(item, Float.parseFloat(S_splt[1]));
-			}
-		}
-		
+		LootTableHandler.LOOT_RAVEN = LootTableHandler.parseLootTable(Modconfig.Raven_Loot);
+		LootTableHandler.LOOT_SEAGULL = LootTableHandler.parseLootTable(Modconfig.Seagull_Loot);
+		LootTableHandler.LOOT_SPECTRAL_RAVEN = LootTableHandler.parseLootTable(Modconfig.Spectral_Raven_Loot);
+
 		for(String S : Modconfig.DreamCatcher_spawn) {
 			String[] S_splt = S.split(",");
 			Class<? extends Entity> entityClass = EntityList.getClass(new ResourceLocation(S_splt[0]));

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/util/LootTableHandler.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/util/LootTableHandler.java
@@ -56,6 +56,7 @@ public class LootTableHandler {
 	public static ResourceLocation AVATON = null;
 	public static Map<Item, Integer> FISHABLE = new HashMap<Item, Integer>();
 	public static Map<ItemStack, Float> LOOT_INTESTINE = new HashMap<ItemStack, Float>();
+	public static Map<Item, Float> LOOT_RAVEN = new HashMap<Item, Float>();
 	public static List<Biome.SpawnListEntry> DREAMCATCHER_LIST = Lists.<Biome.SpawnListEntry>newArrayList();
 	public static List<ResourceLocation> PARASITE_HOSTLIST = Lists.<ResourceLocation>newArrayList();
 	
@@ -101,6 +102,14 @@ public class LootTableHandler {
 					LOOT_INTESTINE.put(new ItemStack(item, 1, Integer.parseInt(S_splt[2])), Float.parseFloat(S_splt[1]));
 				else
 					LOOT_INTESTINE.put(new ItemStack(item, 1, 0), Float.parseFloat(S_splt[1]));
+			}
+		}
+
+		for(String S : Modconfig.Raven_Loot) {
+			String[] S_splt = S.split(",");
+			Item item = Item.getByNameOrId(S_splt[0]);
+			if(item != null) {
+				LOOT_RAVEN.put(item, Float.parseFloat(S_splt[1]));
 			}
 		}
 		


### PR DESCRIPTION
- Added modular functionality for item configurations
- Added configurable raven, spectral raven, and seagull loot tables

This gives us a re-usable function for easier item configuration and should also provide the functionality requested in issue #34.