### PR TITLE
Mitigate intestine sounds

### DIFF
--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/item/ItemIntestine.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/item/ItemIntestine.java
@@ -40,9 +40,9 @@ public class ItemIntestine extends ItemFishCustom
     	ItemStack stack = playerIn.getHeldItem(handIn);
     	
     	if (!playerIn.capabilities.isCreativeMode)stack.shrink(1);
+    	playerIn.playSound(SoundEvents.BLOCK_SLIME_HIT, 1.0F, 1.0F);
     	for(Map.Entry<ItemStack, Float> entry : LootTableHandler.LOOT_INTESTINE.entrySet())
     	{
-    		playerIn.playSound(SoundEvents.BLOCK_SLIME_HIT, 1.0F, 1.0F);
     		if(!worldIn.isRemote && Item.itemRand.nextFloat() < entry.getValue()) {
     			ItemStack s = entry.getKey();
     			s.setCount(Item.itemRand.nextInt(2)+1);


### PR DESCRIPTION
If the intestine loot has a lot of entries, the sound when opening an intestine becomes extremely ear-deafeningly loud because the sound is played for each entry, even if it isn't selected. This PR changes the sound so that it only plays once, which should greatly help in lowering the sound's volume.