### PR TITLE
Fix Infinite Loop in SpawnUtil::getHeight

### DIFF
--- a/forge-1.16.5-36.2.6-mdk/src/main/java/com/Fishmod/mod_LavaCow/core/SpawnUtil.java
+++ b/forge-1.16.5-36.2.6-mdk/src/main/java/com/Fishmod/mod_LavaCow/core/SpawnUtil.java
@@ -45,15 +45,26 @@ public class SpawnUtil {
 	
 	/* Used to determine the relative height */
     public static BlockPos getHeight(Entity entityIn) {
-    	BlockPos position = entityIn.blockPosition();
+		final BlockPos currentPosition = entityIn.blockPosition();
+    	BlockPos groundPosition = entityIn.blockPosition();
 		
-		while(entityIn.level.getBlockState(position).getMaterial().equals(Material.AIR) || entityIn.level.getBlockState(position).getMaterial().equals(Material.LEAVES))
-			position = position.below();
+		while(entityIn.level.getBlockState(groundPosition).getMaterial().equals(Material.AIR) || entityIn.level.getBlockState(groundPosition).getMaterial().equals(Material.LEAVES)) {
+			if (World.isOutsideBuildHeight(groundPosition) && groundPosition.getY() < 0) { // Double-check to account for 1.17+ worlds build heights below 0 may be valid, but also don't want to trigger for being ABOVE build height.
+				mod_LavaCow.LOGGER.warn(String.format("Attempt to get ground position of entity \"%s\" (of type \"%s\", UUID=\"%s\") at \"%s\" resulted in a position below world height - using the entity's current position instead.", entityIn.getDisplayName().getString(), entityIn.getType().getRegistryName(), entityIn.getStringUUID(), currentPosition));
+				return currentPosition;
+			}
+			groundPosition = groundPosition.below();
+		}
 		
-		while(!entityIn.level.getBlockState(position).getMaterial().equals(Material.AIR) && !entityIn.level.getBlockState(position).getMaterial().equals(Material.LEAVES))
-			position = position.above();
+		while(!entityIn.level.getBlockState(groundPosition).getMaterial().equals(Material.AIR) && !entityIn.level.getBlockState(groundPosition).getMaterial().equals(Material.LEAVES)) {
+			if (World.isOutsideBuildHeight(groundPosition)) {
+				mod_LavaCow.LOGGER.warn(String.format("Attempt to get ground position of entity \"%s\" (of type \"%s\", UUID=\"%s\") at \"%s\" resulted in a position above world height - using the entity's current position instead.", entityIn.getDisplayName().getString(), entityIn.getType().getRegistryName(), entityIn.getStringUUID(), currentPosition));
+				return currentPosition;
+			}
+			groundPosition = groundPosition.above();
+		}
 		
-    	return position;
+    	return groundPosition;
     }
     
     /*public static boolean isInsideStructure(World worldIn, String structureName, BlockPos pos) {

--- a/forge-1.16.5-36.2.6-mdk/src/main/java/com/Fishmod/mod_LavaCow/mod_LavaCow.java
+++ b/forge-1.16.5-36.2.6-mdk/src/main/java/com/Fishmod/mod_LavaCow/mod_LavaCow.java
@@ -40,7 +40,7 @@ import java.util.stream.Collectors;
 @Mod.EventBusSubscriber(modid = mod_LavaCow.MODID)
 public class mod_LavaCow {
     // Directly reference a log4j logger.
-    private static final Logger LOGGER = LogManager.getLogger();
+    public static final Logger LOGGER = LogManager.getLogger();
     public static final String MODID = "mod_lavacow";
     public static final String NAME = "Fish's Undead Rising";
     public static ItemGroup TAB = new FURItemGroup();


### PR DESCRIPTION
This would previously crash if the entityIn was in the void, since the .getMaterial().equals(Material.AIR) check returns true for Blocks.VOID_AIR, causing it to infinitely search downward. Fixed by giving up and returning the entity's current position under those circumstances.

To reproduce the bug, go into the void and run `/summon mod_lavacow:banshee`. This will cause the server to freeze (chat messages won't show up, for example), and it will most likely crash after 60 seconds due to that single tick taking too long.