### PR TITLE
[1.12.2] Optimize glowshroom gen logic

### DIFF
--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/worldgen/WorldGenGlowShroom.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/worldgen/WorldGenGlowShroom.java
@@ -27,8 +27,8 @@ public class WorldGenGlowShroom extends WorldGenerator{
         for (int i = 0; i < 64; ++i) {
             BlockPos blockpos = position.add(rand.nextInt(8) - rand.nextInt(8), rand.nextInt(4) - rand.nextInt(4), rand.nextInt(8) - rand.nextInt(8));
 
-            if (worldIn.isAirBlock(blockpos) && worldIn.getLight(blockpos) < 10 && blockpos.getY() < 70 && 
-        		glowshroom.canBlockStay(worldIn, blockpos, glowshroom.getDefaultState()) && rand.nextInt(100) < this.spawnRate) {
+            if (worldIn.isAirBlock(blockpos) && blockpos.getY() < 70 && rand.nextInt(100) < this.spawnRate &&
+        		glowshroom.canBlockStay(worldIn, blockpos, glowshroom.getDefaultState())) {
             	worldIn.setBlockState(blockpos, glowshroom.withAge(rand.nextInt(2)), 2);
             }
         }


### PR DESCRIPTION
Just a quick change to optimize glowshroom generation. Light checks are one of the more costly operations in worldgen performance, and a light check is already done in `BlockGlowShroom#canBlockStay()` [here](https://github.com/FuGu0416/Fishs_Undead_Rising/blob/1.12.2/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/blocks/BlockGlowShroom.java#L131), so it can be removed in the initial checks. `rand` checks should also be faster than `canBlockStay()`, so moved before it.