### PR TITLE
1.12.2 Finished rl combat+sme compat

### DIFF
--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/client/Modconfig.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/client/Modconfig.java
@@ -43,6 +43,7 @@ public class Modconfig {
     public static String[] Parasite_Hostlist = new String[0];
     public static int Parasite_Lifespan;
     public static boolean Parasite_Pickup;
+    public static int Parasite_InfestedAmpSpawns;
 
     public static int pSpawnRate_UndeadSwine;
     public static double UndeadSwine_Health;
@@ -304,6 +305,7 @@ public class Modconfig {
     public static boolean Quark_Compat;
     public static boolean RLCombat_Compat;
     public static boolean SME_Compat;
+    public static boolean SME_Compat_Special;
     public static boolean SunScreen_Mode;
     public static int SpawnRate_Cemetery;
     public static int BoneSword_DamageCap;
@@ -333,7 +335,7 @@ public class Modconfig {
     public static int pSpawnRate_Veilshroom;
     public static boolean MonsterSpawner_Mobs;
 
-    public final String[] usedCategories = {Configuration.CATEGORY_GENERAL, "Amber Lord", "Amber Scarab", "Avaton", "Banshee", "Cactoid", "Cactyrant", "Enigmoth", "Enigmoth Caterpillar", "Foglet", "Slothoman",
+    public final String[] usedCategories = {Configuration.CATEGORY_GENERAL, "Mod Integration", "Mod Integration Toggles", "Amber Lord", "Amber Scarab", "Avaton", "Banshee", "Cactoid", "Cactyrant", "Enigmoth", "Enigmoth Caterpillar", "Foglet", "Slothoman",
             "Imp", "Forsaken", "Frigid", "Ghost Ray", "Ghost Swarmer", "Ithaqua", "Lil' Sludge", "Mimicrab", "Moogma", "Mummy", "Mycosis", "Osvermis", "Parasite", "Penghoul", "Piranha", "Ptera", "Raven", "Warmander",
             "Scarecrow", "Skeleton King", "Sludge Lord", "Swarmer", "Unburied", "Undead Swine", "Undertaker", "Vespa", "Weta", "Sea Hag", "Grave Robber", "Ghost of Grave Robber", "Revenant", "Shroom"};
 
@@ -344,6 +346,7 @@ public class Modconfig {
 
         config.load();
         syncConfigs();
+        config.setCategoryRequiresMcRestart("Mod Integration", true);
     }
 
     private void syncConfigs() {
@@ -379,6 +382,7 @@ public class Modconfig {
         Parasite_Attach = config.get("Parasite", "parasite attacks by attaching onto target", true, "Parasite will attack their target by attaching on them [false/true]").getBoolean(true);
         Parasite_Lifespan = config.get("Parasite", "parasite lifespan", 16, "The amount of seconds before Parasites naturally die or form into cocoons").getInt(16);
         Parasite_Pickup = config.get("Parasite", "parasite pickup", true, "You can pick up Parasites by right clicking them with an empty main hand while sneaking [false/true]").getBoolean(true);
+        Parasite_InfestedAmpSpawns = config.get("Parasite", "parasite infested amplifier spawns", 4, "The maximum amplifier of the Infested potion effect that scales additional parasite spawns").getInt(4);
         Parasite_Hosts = config.get("Parasite", "parasite hosts", true, "Should Parasites have a chance to pop out from dying mobs in the host list or mobs under the Infested effect [false/true]").getBoolean(true);
         Parasite_Hostlist = config.getStringList("Available hosts for parasite", "Parasite",
                 new String[]{
@@ -801,11 +805,16 @@ public class Modconfig {
         ScarabWand_Cooldown = config.get(Configuration.CATEGORY_GENERAL, "scarab scepter cooldown", 60, "Ability cooldown of Scarab Scepter [1-10000]", 1, 10000).getInt(60);
         Undertaker_Shovel_Cooldown = config.get(Configuration.CATEGORY_GENERAL, "midnight mourne cooldown", 60, "Ability cooldown of Midnight Mourne [1-10000]", 1, 10000).getInt(60);
 
-        Tinkers_Compat = config.get(Configuration.CATEGORY_GENERAL, "tinkers' construct integration", true, "Should new tool materials be added to Tinkers' Construct when installed? [false/true]").getBoolean(true);
-        Tinkers_Armor_Compat = config.get(Configuration.CATEGORY_GENERAL, "construct's armory integration", true, "Should new armor materials be added to Construct's Armory when installed? (requires Tinkers' Construct) [false/true]").getBoolean(true);
-        Quark_Compat = config.get(Configuration.CATEGORY_GENERAL, "quark integration", true, "Should new features be added when Quark is also installed? [false/true]").getBoolean(true);
-        RLCombat_Compat = config.get(Configuration.CATEGORY_GENERAL, "rlcombat integration", true, "Should Azrael's Scythe use RLCombat for handling? [false/true]").getBoolean(true);
-        SME_Compat = config.get(Configuration.CATEGORY_GENERAL, "somanyenchantments integration", true, "Should So Many Enchantment's Lesser, Advanced, and Supreme Enchants be considered? [false/true]").getBoolean(true);
+        // Restart Required, loaded during init
+        Tinkers_Compat = config.get("Mod Integration", "tinkers' construct integration", true, "Should new tool materials be added to Tinkers' Construct when installed? [false/true]").getBoolean(true);
+        Tinkers_Armor_Compat = config.get("Mod Integration", "construct's armory integration", true, "Should new armor materials be added to Construct's Armory when installed? (requires Tinkers' Construct) [false/true]").getBoolean(true);
+        Quark_Compat = config.get("Mod Integration", "quark integration", true, "Should new features be added when Quark is also installed? [false/true]").getBoolean(true);
+        RLCombat_Compat = config.get("Mod Integration", "rlcombat integration", true, "Should Azrael's Scythe and Critical Boost use RLCombat for handling offhand bonuses? [false/true]").getBoolean(true);
+        SME_Compat = config.get("Mod Integration", "somanyenchantments integration", true, "Should So Many Enchantment's Lesser, Advanced, and Supreme Enchants be considered? [false/true]").getBoolean(true);
+
+        // Mod Compat that doesn't need restart
+        SME_Compat_Special = config.get("Mod Integration Toggles", "somanyenchantments integration", true, "Should So Many Enchantment's unique enchants work on Fish's Undead Rising item abilities? [false/true]").getBoolean(true);
+
         SunScreen_Mode = config.get(Configuration.CATEGORY_GENERAL, "sunscreen mode", false, "Mobs in this mod will not burn under daylight. [false/true]").getBoolean(false);
 
         SpawnRate_Cemetery = config.get(Configuration.CATEGORY_GENERAL, "cemetery spawn rate", 500, "Spawn rate of Cemetery (higher number = less frequent) [1-10000]", 1, 10000).getInt(500);

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/client/Modconfig.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/client/Modconfig.java
@@ -191,6 +191,8 @@ public class Modconfig {
     public static int SkeletonKing_Ability_Summon_Max;
     public static int SkeletonKing_Minion_Lifespan;
     public static boolean SkeletonKing_Loot_Option;
+    public static boolean SkeletonKing_Biome_Need_All;
+    public static String[] SkeletonKing_Biome_Allowlist;
 
     public static int pSpawnRate_Mummy;
     public static double Mummy_Health;
@@ -550,6 +552,14 @@ public class Modconfig {
         SkeletonKing_Ability_Summon_Max = config.get("Skeleton King", "skeleton king summon max", 24, "Set the max number of Forsaken summoned [0-100]", 0, 100).getInt(24);
         SkeletonKing_Minion_Lifespan = config.get("Skeleton King", "skeleton king minion lifespan", 120, "Summoned Forsaken lifespan [1-10000]", 1, 10000).getInt(120);
         SkeletonKing_Loot_Option = config.get("Skeleton King", "skeleton king loot in chest", true, "Should Skeleton King drop its loot inside a chest [false/true]").getBoolean(true);
+        SkeletonKing_Biome_Need_All = config.get("Skeleton King", "cursed crown need all tags", true, "Should King's Crown require all (or just one) valid biome tag [false/true]").getBoolean(true);
+        SkeletonKing_Biome_Allowlist = config.getStringList("Cursed Crown Biomes List", "Skeleton King",
+                new String[]{
+                        "HOT",
+                        "DRY",
+                        "SANDY"
+                },
+                "Customize the list of Biome tags the King's Crown will check ex. \"DRY\" or \"SANDY\"");
 
         pSpawnRate_Mummy = config.get("Mummy", "mummy spawn rate", 20, "Set the spawn rate of Mummy [0-10000]", 0, 10000).getInt(20);
         Mummy_Health = config.get("Mummy", "mummy health", 24.0D, "Maximum Mummy health [1-1000]", 1, 1000).getDouble(24.0D);

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/client/Modconfig.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/client/Modconfig.java
@@ -284,6 +284,7 @@ public class Modconfig {
     public static int pSpawnRate_Glowshroom;
     public static int pSpreadRate_Glowshroom;
     public static boolean Piranha_AnimalAttack;
+    public static boolean BeastClaw_Needs_Sneak;
     public static int BoneSword_Damage;
     public static boolean BoneSword_Boss_Damage;
     public static int HaloNecklace_Damage;
@@ -734,6 +735,8 @@ public class Modconfig {
         GoldenHeart_Regeneration_Amount = config.get(Configuration.CATEGORY_GENERAL, "golden heart regeneration amount", 8, "Amount of seconds of Regeneration applied by the Golden Heart, 0 = Infinite [0-10000]", 0, 10000).getInt(8);
         GoldenHeart_Repair_Amount = config.get(Configuration.CATEGORY_GENERAL, "golden heart repair amount", 1, "Amount of durability repaired per second by the Golden Heart. [0-10000]", 0, 10000).getInt(1);
         GoldenHeart_RepairsEquipment = config.get(Configuration.CATEGORY_GENERAL, "golden heart repairs equipment", true, "Allow the Golden Heart to repair worn equipment. [false/true]").getBoolean(true);
+
+        BeastClaw_Needs_Sneak = config.get(Configuration.CATEGORY_GENERAL, "beast claw needs sneak", false, "Does Beast Claw right click ability require player to be sneaking?. [false/true]").getBoolean(false);
 
         BoneSword_Boss_Damage = config.get(Configuration.CATEGORY_GENERAL, "bone sword boss damage", false, "Allow the Bone Sword to deal extra damage to bosses. [false/true]").getBoolean(false);
         BoneSword_Damage = config.get(Configuration.CATEGORY_GENERAL, "bone sword bonus damage", 5, "Set the bonus damage of Bone Sword to X% [0-100]", 0, 100).getInt(5);

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/compat/rlcombat/RLCombatCompat.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/compat/rlcombat/RLCombatCompat.java
@@ -1,17 +1,35 @@
 package com.Fishmod.mod_LavaCow.compat.rlcombat;
 
+import bettercombat.mod.event.RLCombatCriticalHitEvent;
 import bettercombat.mod.event.RLCombatSweepEvent;
 import com.Fishmod.mod_LavaCow.init.FishItems;
+import com.Fishmod.mod_LavaCow.init.ModEnchantments;
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 
 public class RLCombatCompat {
 
     /*
-    *   Fixes
-    *   - Offhand Attack getting incorrect sweep modifier
-    *
+     *   - Allow offhand crit to get correct modifier
+     *   - If compat is loaded, cancel original handling
+     */
+    @SubscribeEvent
+    public static void doCritBoost(RLCombatCriticalHitEvent event){
+        EntityLivingBase attacker = event.getEntityPlayer();
+        ItemStack stack = event.getOffhand() ? attacker.getHeldItemOffhand() : attacker.getHeldItemMainhand();
+        if(stack.isEmpty()) return;
+
+        int level = EnchantmentHelper.getEnchantmentLevel(ModEnchantments.CRITICAL_BOOST, stack);
+        if (level > 0) { event.setDamageModifier(event.getDamageModifier() + (level * 0.15F)); }
+    }
+
+    /*
+    *   - Allow offhand sweep to get correct modifier
+    *   - If compat is loaded, cancel original handling
      */
     @SubscribeEvent
     public static void onScytheSweep(RLCombatSweepEvent event) {

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/compat/somanyenchantments/EnchantmentSplitshotHandler.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/compat/somanyenchantments/EnchantmentSplitshotHandler.java
@@ -1,12 +1,12 @@
 package com.Fishmod.mod_LavaCow.compat.somanyenchantments;
 
+import com.Fishmod.mod_LavaCow.client.Modconfig;
 import com.Fishmod.mod_LavaCow.entities.projectiles.*;
 import com.Fishmod.mod_LavaCow.init.FishItems;
 import com.Fishmod.mod_LavaCow.item.ItemPiranhaLauncher;
 import com.shultrea.rin.mixin.vanilla.IItemBowMixin;
 import com.shultrea.rin.registry.EnchantmentRegistry;
 import net.minecraft.enchantment.EnchantmentHelper;
-import net.minecraft.entity.EntityList;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.projectile.EntityArrow;
 import net.minecraft.init.Enchantments;
@@ -19,6 +19,7 @@ public class EnchantmentSplitshotHandler {
 
     @SubscribeEvent
     public void onLauncherStart(PlayerInteractEvent.RightClickItem event){
+        if(!(Modconfig.SME_Compat_Special)) return;
         if(event.getWorld().isRemote) return;
         EntityPlayer player = event.getEntityPlayer();
         if(event.getEntityPlayer() == null) return;
@@ -69,8 +70,9 @@ public class EnchantmentSplitshotHandler {
 
                     // EntityDeathCoil
                     if (stack.getItem() == FishItems.FORSAKEN_STAFF) {
-                        EntityDeathCoil deathCoil = (EntityDeathCoil) EntityList.newEntity(EntityDeathCoil.class, player.world);
-                        if (deathCoil == null) return;
+                        EntityDeathCoil deathCoil = new EntityDeathCoil(player.world, player, 0D, 0D, 0D);
+                        deathCoil.accelerationX = deathCoil.accelerationY = deathCoil.accelerationZ = 0;
+
                         deathCoil.shootingEntity = player;
                         deathCoil.addVelocity(xMod, yMod, zMod);
                         deathCoil.setPosition(player.posX + vector.x, player.posY + (double) (player.height), player.posZ + vector.z);
@@ -86,13 +88,14 @@ public class EnchantmentSplitshotHandler {
                         EntityEnchantableFireBall enchantableFireBall;
                         double ammoMod = 2.5D;
                         if(stack.getItem() == FishItems.PIRANHALAUNCHER){
-                            enchantableFireBall = (EntityEnchantableFireBall) EntityList.newEntity(EntityPiranhaLauncher.class, player.world);
+                            enchantableFireBall = new EntityPiranhaLauncher(player.world, player, 0D, 0D, 0D);
+                            enchantableFireBall.accelerationX = enchantableFireBall.accelerationY = enchantableFireBall.accelerationZ = 0;
                             ammoMod = 2.0D;
                         }
                         else{
-                            enchantableFireBall = (EntityEnchantableFireBall) EntityList.newEntity(EntityWarSmallFireball.class, player.world);
+                            enchantableFireBall = new EntityWarSmallFireball(player.world, player, 0D, 0D, 0D);
+                            enchantableFireBall.accelerationX = enchantableFireBall.accelerationY = enchantableFireBall.accelerationZ = 0;
                         }
-                        if (enchantableFireBall == null) return;
                         enchantableFireBall.shootingEntity = player;
                         enchantableFireBall.addVelocity(xMod * ammoMod, yMod * ammoMod, zMod * ammoMod);
                         enchantableFireBall.setPosition(player.posX + vector.x, player.posY + (double) (player.height), player.posZ + vector.z);

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/compat/somanyenchantments/EnchantmentSplitshotHandler.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/compat/somanyenchantments/EnchantmentSplitshotHandler.java
@@ -33,8 +33,9 @@ public class EnchantmentSplitshotHandler {
         int powerLevel = EnchantmentHelper.getEnchantmentLevel(Enchantments.POWER, stack);
         int punchLevel = EnchantmentHelper.getEnchantmentLevel(Enchantments.PUNCH, stack);
         int flameLevel = EnchantmentHelper.getEnchantmentLevel(Enchantments.FLAME, stack);
-        int advPowerLevel = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.advancedPower, stack);
-        if(advPowerLevel > 0) player.getCooldownTracker().setCooldown(stack.getItem(), 20 - (advPowerLevel * 2));
+
+        powerLevel -= SoManyEnchantmentsCompat.getPowerlessLevel(stack);
+        powerLevel += 5 * SoManyEnchantmentsCompat.getAdvancedPowerLevel(stack) / 3;
 
         int level = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.splitShot, stack);
         if (level > 0) {

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/compat/somanyenchantments/EnchantmentSplitshotHandler.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/compat/somanyenchantments/EnchantmentSplitshotHandler.java
@@ -1,0 +1,110 @@
+package com.Fishmod.mod_LavaCow.compat.somanyenchantments;
+
+import com.Fishmod.mod_LavaCow.entities.projectiles.*;
+import com.Fishmod.mod_LavaCow.init.FishItems;
+import com.Fishmod.mod_LavaCow.item.ItemPiranhaLauncher;
+import com.shultrea.rin.mixin.vanilla.IItemBowMixin;
+import com.shultrea.rin.registry.EnchantmentRegistry;
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.entity.EntityList;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.projectile.EntityArrow;
+import net.minecraft.init.Enchantments;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.Vec3d;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+public class EnchantmentSplitshotHandler {
+
+    @SubscribeEvent
+    public void onLauncherStart(PlayerInteractEvent.RightClickItem event){
+        if(event.getWorld().isRemote) return;
+        EntityPlayer player = event.getEntityPlayer();
+        if(event.getEntityPlayer() == null) return;
+
+        if(!(event.getItemStack().getItem() instanceof ItemPiranhaLauncher)) return;
+        ItemStack stack = event.getItemStack();
+
+        /*
+         * Mostly a copy of original except for some rng calcs to spread out projectiles
+         */
+
+        int powerLevel = EnchantmentHelper.getEnchantmentLevel(Enchantments.POWER, stack);
+        int punchLevel = EnchantmentHelper.getEnchantmentLevel(Enchantments.PUNCH, stack);
+        int flameLevel = EnchantmentHelper.getEnchantmentLevel(Enchantments.FLAME, stack);
+        int advPowerLevel = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.advancedPower, stack);
+        if(advPowerLevel > 0) player.getCooldownTracker().setCooldown(stack.getItem(), 20 - (advPowerLevel * 2));
+
+        int level = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.splitShot, stack);
+        if (level > 0) {
+            // Infinite ammo check
+            boolean flag = stack.getItem() == FishItems.FORSAKEN_STAFF || player.capabilities.isCreativeMode || EnchantmentHelper.getEnchantmentLevel(Enchantments.INFINITY, stack) > 0;
+            ItemStack ammo = ((IItemBowMixin)stack.getItem()).invokeFindAmmo(player);
+            if(ammo.isEmpty()  && !flag) return;
+            for(int x = 0; x < level; ++x) {
+                // EntityArrow
+                if(stack.getItem() == FishItems.THORN_SHOOTER) {
+                    EntityCactusThorn cactusThorn =  new EntityCactusThorn(player.world, player);
+                    cactusThorn.shootingEntity = player;
+                    cactusThorn.shoot(player, player.rotationPitch, player.rotationYaw, 0.0F, 2.0F, 6.0F + player.getRNG().nextFloat() * 12.0F);
+
+                    if (powerLevel > 0) cactusThorn.setDamage(cactusThorn.getDamage() + (double) powerLevel * 0.1D + 0.1D);
+                    if (punchLevel > 0) cactusThorn.setKnockbackStrength(punchLevel);
+                    if (flameLevel > 0) cactusThorn.setFire(100);
+                    stack.damageItem(1, player);
+                    cactusThorn.pickupStatus = EntityArrow.PickupStatus.CREATIVE_ONLY;
+
+                    player.world.spawnEntity(cactusThorn);
+                }
+                else { // EntityFireball
+                    Vec3d vector = player.getLookVec();
+                    vector = vector.rotatePitch((float)Math.toRadians(10D * player.getRNG().nextGaussian()) * (-1 * player.getRNG().nextInt(2)));
+                    vector = vector.rotateYaw((float)Math.toRadians(10D * player.getRNG().nextGaussian()) * (-1 * player.getRNG().nextInt(2)));
+
+                    double xMod = vector.x;
+                    double yMod = vector.y;
+                    double zMod = vector.z;
+
+                    // EntityDeathCoil
+                    if (stack.getItem() == FishItems.FORSAKEN_STAFF) {
+                        EntityDeathCoil deathCoil = (EntityDeathCoil) EntityList.newEntity(EntityDeathCoil.class, player.world);
+                        if (deathCoil == null) return;
+                        deathCoil.shootingEntity = player;
+                        deathCoil.addVelocity(xMod, yMod, zMod);
+                        deathCoil.setPosition(player.posX + vector.x, player.posY + (double) (player.height), player.posZ + vector.z);
+
+                        if (powerLevel > 0) deathCoil.setDamage(deathCoil.getDamage() * (1.0F + (powerLevel + 1) * 0.25F));
+                        if (punchLevel > 0) deathCoil.setKnockbackStrength(punchLevel);
+                        if (flameLevel > 0) deathCoil.setFlame(true);
+                        stack.damageItem(1, player);
+
+                        player.world.spawnEntity(deathCoil);
+                    }
+                    else { // EntityEnchantableFireBall
+                        EntityEnchantableFireBall enchantableFireBall;
+                        double ammoMod = 2.5D;
+                        if(stack.getItem() == FishItems.PIRANHALAUNCHER){
+                            enchantableFireBall = (EntityEnchantableFireBall) EntityList.newEntity(EntityPiranhaLauncher.class, player.world);
+                            ammoMod = 2.0D;
+                        }
+                        else{
+                            enchantableFireBall = (EntityEnchantableFireBall) EntityList.newEntity(EntityWarSmallFireball.class, player.world);
+                        }
+                        if (enchantableFireBall == null) return;
+                        enchantableFireBall.shootingEntity = player;
+                        enchantableFireBall.addVelocity(xMod * ammoMod, yMod * ammoMod, zMod * ammoMod);
+                        enchantableFireBall.setPosition(player.posX + vector.x, player.posY + (double) (player.height), player.posZ + vector.z);
+
+                        if (powerLevel > 0) enchantableFireBall.setDamage(enchantableFireBall.getDamage() * (1.0F + (powerLevel + 1) * 0.25F));
+                        if (punchLevel > 0) enchantableFireBall.setKnockbackStrength(punchLevel);
+                        if (flameLevel > 0) enchantableFireBall.setFlame(true);
+                        stack.damageItem(1, player);
+
+                        player.world.spawnEntity(enchantableFireBall);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/compat/somanyenchantments/LauncherAmmoHandler.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/compat/somanyenchantments/LauncherAmmoHandler.java
@@ -3,8 +3,8 @@ package com.Fishmod.mod_LavaCow.compat.somanyenchantments;
 import com.Fishmod.mod_LavaCow.entities.projectiles.EntityCactusThorn;
 import com.Fishmod.mod_LavaCow.entities.projectiles.EntityDeathCoil;
 import com.Fishmod.mod_LavaCow.entities.projectiles.EntityEnchantableFireBall;
+import com.Fishmod.mod_LavaCow.entities.projectiles.EntityPiranhaLauncher;
 import com.Fishmod.mod_LavaCow.item.ItemPiranhaLauncher;
-import com.Fishmod.mod_LavaCow.mod_LavaCow;
 import com.shultrea.rin.SoManyEnchantments;
 import com.shultrea.rin.properties.ArrowPropertiesProvider;
 import com.shultrea.rin.properties.IArrowProperties;
@@ -14,8 +14,6 @@ import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.projectile.EntityArrow;
-import net.minecraft.entity.projectile.EntityFireball;
-import net.minecraft.item.ItemBow;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EntityDamageSource;
 import net.minecraft.util.ResourceLocation;
@@ -26,24 +24,63 @@ import net.minecraftforge.event.entity.living.LivingDamageEvent;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
-import org.apache.logging.log4j.Level;
 
 import java.util.Random;
 
 // Based on https://github.com/fonnymunkey/SoManyEnchantments/blob/master/src/main/java/com/shultrea/rin/properties/ArrowPropertiesHandler.java#L38
 public class LauncherAmmoHandler {
 
+    // EntityCactusThorn extends EntityArrow
+    // EntityDeathCoil extends EntityWitherSkull extends EntityFireball
+    // EntityPiranhaLauncher extends EntityEnchantableFireBall extends EntityFireball
+    // EntityEnchantableFireBall extends EntityFireball
+    // Safe to assume EntityCactusThorn, EntityDeathCoil, and EntityEnchantableFireBall are only ever Fish Mod
+
+    // Arrow -> Thorn 1/5
+    // 1.25 + 0.75lvl -> (5/2)(3/5) (3/2)(1/5) -> 3/2  3/10
+
+    private static final ResourceLocation ARROWPROPERTIES_CAP_RESOURCE = new ResourceLocation(SoManyEnchantments.MODID + ":arrow_capabilities");
+
+    private static final Random RANDOM = new Random();
+
+    // Covers all the Launcher's Ammo Types
+    public boolean isLauncherAmmo(Object object){
+        return (object instanceof EntityCactusThorn || object instanceof EntityDeathCoil || object instanceof EntityEnchantableFireBall);
+    }
+
+    // Attach caps to Ammo Types except instances of Arrows
+    @SubscribeEvent(priority = EventPriority.HIGH)
+    public void onAttachCapabilitiesEvent(AttachCapabilitiesEvent<Entity> event) {
+        if(!(event.getObject() instanceof EntityArrow) &&
+                isLauncherAmmo(event.getObject()) &&
+                !event.getObject().hasCapability(ArrowPropertiesProvider.ARROWPROPERTIES_CAP, null)) {
+            event.addCapability(ARROWPROPERTIES_CAP_RESOURCE, new ArrowPropertiesProvider());
+        }
+    }
+
+    // Set Props before SME so Cactus Thorn isn't OP, SME checks if props already set
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public void onEntityJoinWorld(EntityJoinWorldEvent event) {
         if(event.getWorld().isRemote) return;
-        mod_LavaCow.logger.log(Level.INFO, "Entity Join");
-        if(!(event.getEntity() instanceof EntityCactusThorn)) return;
-        mod_LavaCow.logger.log(Level.INFO, "Found Thorn");
-        EntityCactusThorn entityArrow = (EntityCactusThorn)event.getEntity();
-        if(!(entityArrow.shootingEntity instanceof EntityLivingBase)) return;
-        EntityLivingBase shooter = (EntityLivingBase)entityArrow.shootingEntity;
+        if(!(isLauncherAmmo(event.getEntity()))) return;
 
-        //I dislike handling this on EntityJoinWorld but mixin'ing into ItemBow has compatibility issues due to other mod bows overriding needed methods
+        EntityLivingBase shooter = null;
+        if(event.getEntity() instanceof EntityCactusThorn){
+            EntityCactusThorn entityArrow = (EntityCactusThorn)event.getEntity();
+            if(!(entityArrow.shootingEntity instanceof EntityLivingBase)) return;
+            shooter = (EntityLivingBase)entityArrow.shootingEntity;
+        }
+        else if(event.getEntity() instanceof EntityDeathCoil){
+            EntityDeathCoil entityArrow = (EntityDeathCoil)event.getEntity();
+            if(!(entityArrow.shootingEntity instanceof EntityLivingBase)) return;
+            shooter = entityArrow.shootingEntity;
+        }
+        else if(event.getEntity() instanceof EntityEnchantableFireBall){
+            EntityEnchantableFireBall entityArrow = (EntityEnchantableFireBall)event.getEntity();
+            if(!(entityArrow.shootingEntity instanceof EntityLivingBase)) return;
+            shooter = entityArrow.shootingEntity;
+        }
+
         ItemStack bow = shooter.getHeldItemMainhand();
         if(!(bow.getItem() instanceof ItemPiranhaLauncher)) {
             bow = shooter.getHeldItemOffhand();
@@ -52,308 +89,195 @@ public class LauncherAmmoHandler {
             return;
         }
 
-        IArrowProperties properties = entityArrow.getCapability(ArrowPropertiesProvider.ARROWPROPERTIES_CAP, null);
+        IArrowProperties properties = event.getEntity().getCapability(ArrowPropertiesProvider.ARROWPROPERTIES_CAP, null);
         if(properties == null) return;
 
-        //Avoid overwriting if properties were already set for this entity for whatever reason
         if(properties.getPropertiesHandled()) return;
-        if(EnchantmentRegistry.advancedPower.isEnabled()) {
-            int advPowerLevel = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.advancedPower, bow);
-            if(advPowerLevel > 0) {
-                entityArrow.setDamage(entityArrow.getDamage() + 11110.25D + (double)advPowerLevel * 0.75D);
-            }
-        }
+        if(event.getEntity() instanceof EntityCactusThorn)
+            setArrowEnchantmentsFromStack(bow, event.getEntity(), properties);
+        else if(event.getEntity() instanceof EntityDeathCoil)
+            setArrowEnchantmentsFromStack(bow, event.getEntity(), properties);
+        else if(event.getEntity() instanceof EntityEnchantableFireBall)
+            setArrowEnchantmentsFromStack(bow, event.getEntity(), properties);
         properties.setPropertiesHandled(true);
     }
 
-//    private static final ResourceLocation ARROWPROPERTIES_CAP_RESOURCE = new ResourceLocation(SoManyEnchantments.MODID + ":arrow_capabilities");
-//
-//    private static final Random RANDOM = new Random();
-//
-//    @SubscribeEvent(priority = EventPriority.HIGH)
-//    public void onAttachCapabilitiesEvent(AttachCapabilitiesEvent<Entity> event) {
-//        mod_LavaCow.logger.log(Level.INFO, "Trying to attaching caps to :" + event.getObject());
-//        if(isLauncherAmmo(event.getObject()) && !event.getObject().hasCapability(ArrowPropertiesProvider.ARROWPROPERTIES_CAP, null)) {
-//            event.addCapability(ARROWPROPERTIES_CAP_RESOURCE, new ArrowPropertiesProvider());
-//        }
-//    }
-//
-//    // Set Props before SME so Cactus Thorn as SME won't overwrite
-//    @SubscribeEvent(priority = EventPriority.HIGHEST)
-//    public void onEntityJoinWorld(EntityJoinWorldEvent event) {
-//        if(event.getWorld().isRemote) return;
-//        if(!(isLauncherAmmo(event.getEntity()))) return;
-//
-//        mod_LavaCow.logger.log(Level.INFO, "Trying to process :" + event.getEntity());
-//
-//        EntityLivingBase shooter = null;
-//        if(event.getEntity() instanceof EntityCactusThorn){
-//            EntityCactusThorn entityArrow = (EntityCactusThorn)event.getEntity();
-//            if(!(entityArrow.shootingEntity instanceof EntityLivingBase)) return;
-//            shooter = (EntityLivingBase)entityArrow.shootingEntity;
-//        }
-//        else if(event.getEntity() instanceof EntityDeathCoil){
-//            EntityDeathCoil entityArrow = (EntityDeathCoil)event.getEntity();
-//            if(!(entityArrow.shootingEntity instanceof EntityLivingBase)) return;
-//            shooter = entityArrow.shootingEntity;
-//        }
-//        else if(event.getEntity() instanceof EntityEnchantableFireBall){
-//            EntityEnchantableFireBall entityArrow = (EntityEnchantableFireBall)event.getEntity();
-//            if(!(entityArrow.shootingEntity instanceof EntityLivingBase)) return;
-//            shooter = entityArrow.shootingEntity;
-//        }
-//
-//        ItemStack bow = shooter.getHeldItemMainhand();
-//        if(!(bow.getItem() instanceof ItemPiranhaLauncher)) {
-//            bow = shooter.getHeldItemOffhand();
-//        }
-//        if(!(bow.getItem() instanceof ItemPiranhaLauncher)) {
-//            return;
-//        }
-//
-//        IArrowProperties properties = event.getEntity().getCapability(ArrowPropertiesProvider.ARROWPROPERTIES_CAP, null);
-//        if(properties == null) return;
-//
-//        //Avoid overwriting if properties were already set for this entity for whatever reason
-//        if(properties.getPropertiesHandled()) return;
-//        if(event.getEntity() instanceof EntityCactusThorn)
-//            setArrowEnchantmentsFromStack(bow, (EntityCactusThorn)event.getEntity(), properties);
-//        else if(event.getEntity() instanceof EntityEnchantableFireBall)
-//            setArrowEnchantmentsFromStack(bow, (EntityEnchantableFireBall)event.getEntity(), properties);
-//        properties.setPropertiesHandled(true);
-//    }
+    // Cactus Thorn is an EntityArrow, handled by SME
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    public void onLauncherHitHurt(LivingHurtEvent event) {
+        if(!(event.getSource().getImmediateSource() instanceof EntityEnchantableFireBall) &&
+                !(event.getSource().getImmediateSource() instanceof EntityDeathCoil)) return;
 
-//    @SubscribeEvent(priority = EventPriority.LOWEST)
-//    public void onArrowHitHurt(LivingHurtEvent event) {
-//        if(!(event.getSource().getImmediateSource() instanceof EntityArrow)) return;
-//        if(!"arrow".equals(event.getSource().damageType)) return;
-//
-//        EntityArrow arrow = (EntityArrow)event.getSource().getImmediateSource();
-//        EntityLivingBase victim = event.getEntityLiving();
-//
-//        IArrowProperties properties = arrow.getCapability(ArrowPropertiesProvider.ARROWPROPERTIES_CAP, null);
-//        if(properties == null) return;
-//
-//        if(EnchantmentRegistry.runeArrowPiercing.isEnabled()) {
-//            int pierceLevel = properties.getArmorPiercingLevel();
-//            if(pierceLevel > 0) {
-//                if(event.getSource() instanceof EntityDamageSource) {
-//                    float currPercent = ((IEntityDamageSourceMixin)event.getSource()).soManyEnchantments$getPiercingPercent();
-//                    float percent = Math.min(currPercent + 0.25F * (float)pierceLevel, 1.0F);
-//                    ((IEntityDamageSourceMixin)event.getSource()).soManyEnchantments$setPiercingPercent(percent);
-//                }
-//            }
-//        }
-//    }
+        Entity arrow = event.getSource().getImmediateSource();
 
-//    @SubscribeEvent
-//    public void onArrowHitDamage(LivingDamageEvent event) {
-//        if(!(event.getSource().getImmediateSource() instanceof EntityArrow)) return;
-//        if(!"arrow".equals(event.getSource().damageType)) return;
-//
-//        EntityArrow arrow = (EntityArrow)event.getSource().getImmediateSource();
-//        EntityLivingBase victim = event.getEntityLiving();
-//
-//        IArrowProperties properties = arrow.getCapability(ArrowPropertiesProvider.ARROWPROPERTIES_CAP, null);
-//        if(properties == null) return;
-//
-//        if(EnchantmentRegistry.lesserFlame.isEnabled() || EnchantmentRegistry.advancedFlame.isEnabled() || EnchantmentRegistry.supremeFlame.isEnabled()) {
-//            int seconds = getFireSeconds(properties.getFlameLevel());
-//            if(seconds > 0) victim.setFire(seconds);
-//        }
-//
-//        if(EnchantmentRegistry.extinguish.isEnabled()) {
-//            int flameLevel = properties.getFlameLevel();
-//            if(flameLevel == -1) victim.extinguish();
-//        }
-//
-//        if(EnchantmentRegistry.dragging.isEnabled()) {
-//            float draggingPower = properties.getDraggingPower();
-//            if(draggingPower > 0) {
-//                double velocityMultiplier = -0.6F * draggingPower / MathHelper.sqrt(arrow.motionX * arrow.motionX + arrow.motionZ * arrow.motionZ);
-//                victim.addVelocity(arrow.motionX * velocityMultiplier, 0.1, arrow.motionZ * velocityMultiplier);
-//                victim.velocityChanged = true;
-//            }
-//        }
-//
-//        if(EnchantmentRegistry.strafe.isEnabled()) {
-//            if(properties.getArrowResetsIFrames()) {
-//                victim.hurtResistantTime = 0;
-//            }
-//        }
-//    }
+        IArrowProperties properties = arrow.getCapability(ArrowPropertiesProvider.ARROWPROPERTIES_CAP, null);
+        if(properties == null) return;
 
-//    private static int getFireSeconds(int tier) {
-//        switch(tier) {
-//            case 1:
-//                return 2;
-//            case 2:
-//                return 15;
-//            case 3:
-//                return 30;
-//        }
-//        return 0;
-//    }
-//
-//    public static void setArrowEnchantmentsFromStack(ItemStack bow, EntityEnchantableFireBall arrow, IArrowProperties properties) {
-//        if(EnchantmentRegistry.powerless.isEnabled()) {
-//            int powerlessLevel = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.powerless, bow);
-//            if(powerlessLevel > 0) {
-//                arrow.setDamage((int)(arrow.getDamage() - 0.5D - powerlessLevel * 0.5D));
-//            }
-//        }
-//
-//        if(EnchantmentRegistry.advancedPower.isEnabled()) {
-//            int advPowerLevel = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.advancedPower, bow);
-//            if(advPowerLevel > 0) {
-//                arrow.setDamage((int)(arrow.getDamage() + 1.25D + (double)advPowerLevel * 0.75D));
-//            }
-//        }
-//
-//        if(EnchantmentRegistry.advancedPunch.isEnabled()) {
-//            int advPunchLevel = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.advancedPunch, bow);
-//            if(advPunchLevel > 0) {
-//                arrow.setKnockbackStrength(1 + advPunchLevel * 2);
-//            }
-//        }
-//
-//        if(EnchantmentRegistry.runeArrowPiercing.isEnabled()) {
-//            int runeArrowPiercingLevel = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.runeArrowPiercing, bow);
-//            if(runeArrowPiercingLevel > 0) {
-//                properties.setArmorPiercingLevel(runeArrowPiercingLevel);
-//            }
-//        }
-//
-//        if(EnchantmentRegistry.dragging.isEnabled()) {
-//            int draggingLevel = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.dragging, bow);
-//            if(draggingLevel > 0) {
-//                properties.setDraggingPower(1.25F + draggingLevel * 1.75F);
-//            }
-//        }
-//
-//        if(EnchantmentRegistry.strafe.isEnabled()) {
-//            int levelStrafe = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.strafe, bow);
-//            if(RANDOM.nextFloat() < 0.125F * levelStrafe) {
-//                properties.setArrowResetsIFrames(true);
-//            }
-//        }
-//
-//        if(EnchantmentRegistry.lesserFlame.isEnabled()) {
-//            int levelLessFlame = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.lesserFlame, bow);
-//            if(levelLessFlame > 0) {
-//                arrow.setFire(50);
-//                properties.setFlameLevel(1);
-//            }
-//        }
-//
-//        if(EnchantmentRegistry.advancedFlame.isEnabled()) {
-//            int levelAdvFlame = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.advancedFlame, bow);
-//            if(levelAdvFlame > 0) {
-//                arrow.setFire(200);
-//                properties.setFlameLevel(2);
-//            }
-//        }
-//
-//        if(EnchantmentRegistry.supremeFlame.isEnabled()) {
-//            int levelSupFlame = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.supremeFlame, bow);
-//            if(levelSupFlame > 0) {
-//                arrow.setFire(400);
-//                properties.setFlameLevel(3);
-//            }
-//        }
-//
-//        if(EnchantmentRegistry.extinguish.isEnabled()) {
-//            int levelExtinguish = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.extinguish, bow);
-//            if(levelExtinguish > 0) {
-//                arrow.extinguish();
-//                properties.setFlameLevel(-1);
-//            }
-//        }
-//    }
-//
-//    public static void setArrowEnchantmentsFromStack(ItemStack bow, EntityCactusThorn arrow, IArrowProperties properties) {
-//        if(EnchantmentRegistry.powerless.isEnabled()) {
-//            int powerlessLevel = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.powerless, bow);
-//            if(powerlessLevel > 0) {
-//                arrow.setDamage(arrow.getDamage() - 0.5D - powerlessLevel * 0.5D);
-//                if(powerlessLevel > 2 || RANDOM.nextFloat() < powerlessLevel * 0.4F) {
-//                    arrow.setIsCritical(false);
-//                }
-//            }
-//        }
-//
-//        if(EnchantmentRegistry.advancedPower.isEnabled()) {
-//            int advPowerLevel = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.advancedPower, bow);
-//            if(advPowerLevel > 0) {
-//                arrow.setDamage(arrow.getDamage() + 0.25D + (double)advPowerLevel * 0.75D);
-//                if(advPowerLevel >= 4 || RANDOM.nextFloat() < advPowerLevel * 0.25F) {
-//                    arrow.setIsCritical(true);
-//                }
-//            }
-//        }
-//
-//        if(EnchantmentRegistry.advancedPunch.isEnabled()) {
-//            int advPunchLevel = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.advancedPunch, bow);
-//            if(advPunchLevel > 0) {
-//                arrow.setKnockbackStrength(1 + advPunchLevel * 2);
-//            }
-//        }
-//
-//        if(EnchantmentRegistry.runeArrowPiercing.isEnabled()) {
-//            int runeArrowPiercingLevel = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.runeArrowPiercing, bow);
-//            if(runeArrowPiercingLevel > 0) {
-//                properties.setArmorPiercingLevel(runeArrowPiercingLevel);
-//            }
-//        }
-//
-//        if(EnchantmentRegistry.dragging.isEnabled()) {
-//            int draggingLevel = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.dragging, bow);
-//            if(draggingLevel > 0) {
-//                properties.setDraggingPower(1.25F + draggingLevel * 1.75F);
-//            }
-//        }
-//
-//        if(EnchantmentRegistry.strafe.isEnabled()) {
-//            int levelStrafe = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.strafe, bow);
-//            if(RANDOM.nextFloat() < 0.125F * levelStrafe) {
-//                properties.setArrowResetsIFrames(true);
-//            }
-//        }
-//
-//        if(EnchantmentRegistry.lesserFlame.isEnabled()) {
-//            int levelLessFlame = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.lesserFlame, bow);
-//            if(levelLessFlame > 0) {
-//                arrow.setFire(50);
-//                properties.setFlameLevel(1);
-//            }
-//        }
-//
-//        if(EnchantmentRegistry.advancedFlame.isEnabled()) {
-//            int levelAdvFlame = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.advancedFlame, bow);
-//            if(levelAdvFlame > 0) {
-//                arrow.setFire(200);
-//                properties.setFlameLevel(2);
-//            }
-//        }
-//
-//        if(EnchantmentRegistry.supremeFlame.isEnabled()) {
-//            int levelSupFlame = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.supremeFlame, bow);
-//            if(levelSupFlame > 0) {
-//                arrow.setFire(400);
-//                properties.setFlameLevel(3);
-//            }
-//        }
-//
-//        if(EnchantmentRegistry.extinguish.isEnabled()) {
-//            int levelExtinguish = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.extinguish, bow);
-//            if(levelExtinguish > 0) {
-//                arrow.extinguish();
-//                properties.setFlameLevel(-1);
-//            }
-//        }
-//    }
-//
-//    public boolean isLauncherAmmo(Object object){
-//        return (object instanceof  EntityCactusThorn || object instanceof EntityDeathCoil || object instanceof EntityEnchantableFireBall);
-//    }
+        if(EnchantmentRegistry.runeArrowPiercing.isEnabled()) {
+            int pierceLevel = properties.getArmorPiercingLevel();
+            if(pierceLevel > 0) {
+                if(event.getSource() instanceof EntityDamageSource) {
+                    float currPercent = ((IEntityDamageSourceMixin)event.getSource()).soManyEnchantments$getPiercingPercent();
+                    float percent = Math.min(currPercent + 0.25F * (float)pierceLevel, 1.0F);
+                    ((IEntityDamageSourceMixin)event.getSource()).soManyEnchantments$setPiercingPercent(percent);
+                }
+            }
+        }
+    }
+
+    // Cactus Thorn is an EntityArrow, handled by SME
+    @SubscribeEvent
+    public void onLauncherHitDamage(LivingDamageEvent event) {
+        if(!(event.getSource().getImmediateSource() instanceof EntityEnchantableFireBall) &&
+                !(event.getSource().getImmediateSource() instanceof EntityDeathCoil)) return;
+
+        Entity arrow = event.getSource().getImmediateSource();
+        EntityLivingBase victim = event.getEntityLiving();
+
+        IArrowProperties properties = arrow.getCapability(ArrowPropertiesProvider.ARROWPROPERTIES_CAP, null);
+        if(properties == null) return;
+
+        if(EnchantmentRegistry.lesserFlame.isEnabled() || EnchantmentRegistry.advancedFlame.isEnabled() || EnchantmentRegistry.supremeFlame.isEnabled()) {
+            int seconds = getFireSeconds(properties.getFlameLevel());
+            if(seconds > 0) victim.setFire(seconds);
+        }
+
+        if(EnchantmentRegistry.extinguish.isEnabled()) {
+            int flameLevel = properties.getFlameLevel();
+            if(flameLevel == -1) victim.extinguish();
+        }
+
+        if(EnchantmentRegistry.dragging.isEnabled()) {
+            float draggingPower = properties.getDraggingPower();
+            if(draggingPower > 0) {
+                double velocityMultiplier = -0.6F * draggingPower / MathHelper.sqrt(arrow.motionX * arrow.motionX + arrow.motionZ * arrow.motionZ);
+                victim.addVelocity(arrow.motionX * velocityMultiplier, 0.1, arrow.motionZ * velocityMultiplier);
+                victim.velocityChanged = true;
+            }
+        }
+
+        if(EnchantmentRegistry.strafe.isEnabled()) {
+            if(properties.getArrowResetsIFrames()) {
+                victim.hurtResistantTime = 0;
+            }
+        }
+    }
+
+    private static int getFireSeconds(int tier) {
+        switch(tier) {
+            case 1:
+                return 2;
+            case 2:
+                return 15;
+            case 3:
+                return 30;
+        }
+        return 0;
+    }
+
+    // This is ridiculous
+    // Arrow -> Thorn 1/5
+    // Other -> 2.5x Flat + 1.5xlvl
+    public static void setArrowEnchantmentsFromStack(ItemStack bow, Entity arrow, IArrowProperties properties) {
+        boolean isDeathCoil = arrow instanceof EntityDeathCoil;
+        boolean ispiranha = arrow instanceof EntityPiranhaLauncher;
+        boolean isFireBall = arrow instanceof EntityEnchantableFireBall;
+        boolean isCactusThorn = arrow instanceof EntityCactusThorn;
+
+        if(!isDeathCoil && !isFireBall && !isCactusThorn) return;
+
+        if(EnchantmentRegistry.powerless.isEnabled()) {
+            int powerlessLevel = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.powerless, bow);
+            if(powerlessLevel > 0) {
+                if(isDeathCoil) ((EntityDeathCoil)arrow).setDamage((int)(((EntityDeathCoil)arrow).getDamage() / (1.25D + (double)powerlessLevel * 0.25D)));
+                else if(ispiranha) ((EntityPiranhaLauncher)arrow).setDamage((int)(((EntityPiranhaLauncher)arrow).getDamage() / (1.25D + (double)powerlessLevel * 0.25D)));
+                else if(isFireBall) ((EntityEnchantableFireBall)arrow).setDamage((int)(((EntityEnchantableFireBall)arrow).getDamage() / (1.25D + (double)powerlessLevel * 0.25D)));
+                else {
+                    ((EntityCactusThorn)arrow).setDamage(((EntityCactusThorn)arrow).getDamage() - (0.1D - (double)powerlessLevel * 0.1D));
+                    if (powerlessLevel > 2 || RANDOM.nextFloat() < powerlessLevel * 0.4F) {
+                        ((EntityCactusThorn)arrow).setIsCritical(false);
+                    }
+                }
+            }
+        }
+
+        if(EnchantmentRegistry.advancedPower.isEnabled()) {
+            int advPowerLevel = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.advancedPower, bow);
+            if(advPowerLevel > 0) {
+                if(isDeathCoil) ((EntityDeathCoil)arrow).setDamage((int)(((EntityDeathCoil)arrow).getDamage() * (1.875D + (double)advPowerLevel * 0.225D)));
+                else if(ispiranha) ((EntityPiranhaLauncher)arrow).setDamage((int)(((EntityPiranhaLauncher)arrow).getDamage() * (1.875D + (double)advPowerLevel * 0.225D)));
+                else if(isFireBall) ((EntityEnchantableFireBall)arrow).setDamage((int)(((EntityEnchantableFireBall)arrow).getDamage() * (1.875D + (double)advPowerLevel * 0.225D)));
+                else {
+                    ((EntityCactusThorn)arrow).setDamage(((EntityCactusThorn)arrow).getDamage() + (0.05D + (double)advPowerLevel * 0.15D));
+                    if(advPowerLevel >= 4 || RANDOM.nextFloat() < advPowerLevel * 0.25F) {
+                        ((EntityCactusThorn)arrow).setIsCritical(true);
+                    }
+                }
+            }
+        }
+
+        if(EnchantmentRegistry.advancedPunch.isEnabled()) {
+            int advPunchLevel = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.advancedPunch, bow);
+            if(advPunchLevel > 0) {
+                if(isDeathCoil) ((EntityDeathCoil)arrow).setKnockbackStrength(1 + advPunchLevel * 2);
+                else if(isFireBall) ((EntityEnchantableFireBall)arrow).setKnockbackStrength(1 + advPunchLevel * 2);
+                else {
+                    ((EntityCactusThorn)arrow).setKnockbackStrength(1 + advPunchLevel * 2);
+                }
+            }
+        }
+
+        if(EnchantmentRegistry.runeArrowPiercing.isEnabled()) {
+            int runeArrowPiercingLevel = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.runeArrowPiercing, bow);
+            if(runeArrowPiercingLevel > 0) {
+                properties.setArmorPiercingLevel(runeArrowPiercingLevel);
+            }
+        }
+
+        if(EnchantmentRegistry.dragging.isEnabled()) {
+            int draggingLevel = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.dragging, bow);
+            if(draggingLevel > 0) {
+                properties.setDraggingPower(1.25F + draggingLevel * 1.75F);
+            }
+        }
+
+        if(EnchantmentRegistry.strafe.isEnabled()) {
+            int levelStrafe = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.strafe, bow);
+            if(RANDOM.nextFloat() < 0.125F * levelStrafe) {
+                properties.setArrowResetsIFrames(true);
+            }
+        }
+
+        if(EnchantmentRegistry.lesserFlame.isEnabled()) {
+            int levelLessFlame = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.lesserFlame, bow);
+            if(levelLessFlame > 0) {
+                arrow.setFire(50);
+                properties.setFlameLevel(1);
+            }
+        }
+
+        if(EnchantmentRegistry.advancedFlame.isEnabled()) {
+            int levelAdvFlame = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.advancedFlame, bow);
+            if(levelAdvFlame > 0) {
+                arrow.setFire(200);
+                properties.setFlameLevel(2);
+            }
+        }
+
+        if(EnchantmentRegistry.supremeFlame.isEnabled()) {
+            int levelSupFlame = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.supremeFlame, bow);
+            if(levelSupFlame > 0) {
+                arrow.setFire(400);
+                properties.setFlameLevel(3);
+            }
+        }
+
+        if(EnchantmentRegistry.extinguish.isEnabled()) {
+            int levelExtinguish = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.extinguish, bow);
+            if(levelExtinguish > 0) {
+                arrow.extinguish();
+                properties.setFlameLevel(-1);
+            }
+        }
+    }
 }

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/compat/somanyenchantments/LauncherAmmoHandler.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/compat/somanyenchantments/LauncherAmmoHandler.java
@@ -1,0 +1,359 @@
+package com.Fishmod.mod_LavaCow.compat.somanyenchantments;
+
+import com.Fishmod.mod_LavaCow.entities.projectiles.EntityCactusThorn;
+import com.Fishmod.mod_LavaCow.entities.projectiles.EntityDeathCoil;
+import com.Fishmod.mod_LavaCow.entities.projectiles.EntityEnchantableFireBall;
+import com.Fishmod.mod_LavaCow.item.ItemPiranhaLauncher;
+import com.Fishmod.mod_LavaCow.mod_LavaCow;
+import com.shultrea.rin.SoManyEnchantments;
+import com.shultrea.rin.properties.ArrowPropertiesProvider;
+import com.shultrea.rin.properties.IArrowProperties;
+import com.shultrea.rin.registry.EnchantmentRegistry;
+import com.shultrea.rin.util.IEntityDamageSourceMixin;
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.projectile.EntityArrow;
+import net.minecraft.entity.projectile.EntityFireball;
+import net.minecraft.item.ItemBow;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EntityDamageSource;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.MathHelper;
+import net.minecraftforge.event.AttachCapabilitiesEvent;
+import net.minecraftforge.event.entity.EntityJoinWorldEvent;
+import net.minecraftforge.event.entity.living.LivingDamageEvent;
+import net.minecraftforge.event.entity.living.LivingHurtEvent;
+import net.minecraftforge.fml.common.eventhandler.EventPriority;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import org.apache.logging.log4j.Level;
+
+import java.util.Random;
+
+// Based on https://github.com/fonnymunkey/SoManyEnchantments/blob/master/src/main/java/com/shultrea/rin/properties/ArrowPropertiesHandler.java#L38
+public class LauncherAmmoHandler {
+
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
+    public void onEntityJoinWorld(EntityJoinWorldEvent event) {
+        if(event.getWorld().isRemote) return;
+        mod_LavaCow.logger.log(Level.INFO, "Entity Join");
+        if(!(event.getEntity() instanceof EntityCactusThorn)) return;
+        mod_LavaCow.logger.log(Level.INFO, "Found Thorn");
+        EntityCactusThorn entityArrow = (EntityCactusThorn)event.getEntity();
+        if(!(entityArrow.shootingEntity instanceof EntityLivingBase)) return;
+        EntityLivingBase shooter = (EntityLivingBase)entityArrow.shootingEntity;
+
+        //I dislike handling this on EntityJoinWorld but mixin'ing into ItemBow has compatibility issues due to other mod bows overriding needed methods
+        ItemStack bow = shooter.getHeldItemMainhand();
+        if(!(bow.getItem() instanceof ItemPiranhaLauncher)) {
+            bow = shooter.getHeldItemOffhand();
+        }
+        if(!(bow.getItem() instanceof ItemPiranhaLauncher)) {
+            return;
+        }
+
+        IArrowProperties properties = entityArrow.getCapability(ArrowPropertiesProvider.ARROWPROPERTIES_CAP, null);
+        if(properties == null) return;
+
+        //Avoid overwriting if properties were already set for this entity for whatever reason
+        if(properties.getPropertiesHandled()) return;
+        if(EnchantmentRegistry.advancedPower.isEnabled()) {
+            int advPowerLevel = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.advancedPower, bow);
+            if(advPowerLevel > 0) {
+                entityArrow.setDamage(entityArrow.getDamage() + 11110.25D + (double)advPowerLevel * 0.75D);
+            }
+        }
+        properties.setPropertiesHandled(true);
+    }
+
+//    private static final ResourceLocation ARROWPROPERTIES_CAP_RESOURCE = new ResourceLocation(SoManyEnchantments.MODID + ":arrow_capabilities");
+//
+//    private static final Random RANDOM = new Random();
+//
+//    @SubscribeEvent(priority = EventPriority.HIGH)
+//    public void onAttachCapabilitiesEvent(AttachCapabilitiesEvent<Entity> event) {
+//        mod_LavaCow.logger.log(Level.INFO, "Trying to attaching caps to :" + event.getObject());
+//        if(isLauncherAmmo(event.getObject()) && !event.getObject().hasCapability(ArrowPropertiesProvider.ARROWPROPERTIES_CAP, null)) {
+//            event.addCapability(ARROWPROPERTIES_CAP_RESOURCE, new ArrowPropertiesProvider());
+//        }
+//    }
+//
+//    // Set Props before SME so Cactus Thorn as SME won't overwrite
+//    @SubscribeEvent(priority = EventPriority.HIGHEST)
+//    public void onEntityJoinWorld(EntityJoinWorldEvent event) {
+//        if(event.getWorld().isRemote) return;
+//        if(!(isLauncherAmmo(event.getEntity()))) return;
+//
+//        mod_LavaCow.logger.log(Level.INFO, "Trying to process :" + event.getEntity());
+//
+//        EntityLivingBase shooter = null;
+//        if(event.getEntity() instanceof EntityCactusThorn){
+//            EntityCactusThorn entityArrow = (EntityCactusThorn)event.getEntity();
+//            if(!(entityArrow.shootingEntity instanceof EntityLivingBase)) return;
+//            shooter = (EntityLivingBase)entityArrow.shootingEntity;
+//        }
+//        else if(event.getEntity() instanceof EntityDeathCoil){
+//            EntityDeathCoil entityArrow = (EntityDeathCoil)event.getEntity();
+//            if(!(entityArrow.shootingEntity instanceof EntityLivingBase)) return;
+//            shooter = entityArrow.shootingEntity;
+//        }
+//        else if(event.getEntity() instanceof EntityEnchantableFireBall){
+//            EntityEnchantableFireBall entityArrow = (EntityEnchantableFireBall)event.getEntity();
+//            if(!(entityArrow.shootingEntity instanceof EntityLivingBase)) return;
+//            shooter = entityArrow.shootingEntity;
+//        }
+//
+//        ItemStack bow = shooter.getHeldItemMainhand();
+//        if(!(bow.getItem() instanceof ItemPiranhaLauncher)) {
+//            bow = shooter.getHeldItemOffhand();
+//        }
+//        if(!(bow.getItem() instanceof ItemPiranhaLauncher)) {
+//            return;
+//        }
+//
+//        IArrowProperties properties = event.getEntity().getCapability(ArrowPropertiesProvider.ARROWPROPERTIES_CAP, null);
+//        if(properties == null) return;
+//
+//        //Avoid overwriting if properties were already set for this entity for whatever reason
+//        if(properties.getPropertiesHandled()) return;
+//        if(event.getEntity() instanceof EntityCactusThorn)
+//            setArrowEnchantmentsFromStack(bow, (EntityCactusThorn)event.getEntity(), properties);
+//        else if(event.getEntity() instanceof EntityEnchantableFireBall)
+//            setArrowEnchantmentsFromStack(bow, (EntityEnchantableFireBall)event.getEntity(), properties);
+//        properties.setPropertiesHandled(true);
+//    }
+
+//    @SubscribeEvent(priority = EventPriority.LOWEST)
+//    public void onArrowHitHurt(LivingHurtEvent event) {
+//        if(!(event.getSource().getImmediateSource() instanceof EntityArrow)) return;
+//        if(!"arrow".equals(event.getSource().damageType)) return;
+//
+//        EntityArrow arrow = (EntityArrow)event.getSource().getImmediateSource();
+//        EntityLivingBase victim = event.getEntityLiving();
+//
+//        IArrowProperties properties = arrow.getCapability(ArrowPropertiesProvider.ARROWPROPERTIES_CAP, null);
+//        if(properties == null) return;
+//
+//        if(EnchantmentRegistry.runeArrowPiercing.isEnabled()) {
+//            int pierceLevel = properties.getArmorPiercingLevel();
+//            if(pierceLevel > 0) {
+//                if(event.getSource() instanceof EntityDamageSource) {
+//                    float currPercent = ((IEntityDamageSourceMixin)event.getSource()).soManyEnchantments$getPiercingPercent();
+//                    float percent = Math.min(currPercent + 0.25F * (float)pierceLevel, 1.0F);
+//                    ((IEntityDamageSourceMixin)event.getSource()).soManyEnchantments$setPiercingPercent(percent);
+//                }
+//            }
+//        }
+//    }
+
+//    @SubscribeEvent
+//    public void onArrowHitDamage(LivingDamageEvent event) {
+//        if(!(event.getSource().getImmediateSource() instanceof EntityArrow)) return;
+//        if(!"arrow".equals(event.getSource().damageType)) return;
+//
+//        EntityArrow arrow = (EntityArrow)event.getSource().getImmediateSource();
+//        EntityLivingBase victim = event.getEntityLiving();
+//
+//        IArrowProperties properties = arrow.getCapability(ArrowPropertiesProvider.ARROWPROPERTIES_CAP, null);
+//        if(properties == null) return;
+//
+//        if(EnchantmentRegistry.lesserFlame.isEnabled() || EnchantmentRegistry.advancedFlame.isEnabled() || EnchantmentRegistry.supremeFlame.isEnabled()) {
+//            int seconds = getFireSeconds(properties.getFlameLevel());
+//            if(seconds > 0) victim.setFire(seconds);
+//        }
+//
+//        if(EnchantmentRegistry.extinguish.isEnabled()) {
+//            int flameLevel = properties.getFlameLevel();
+//            if(flameLevel == -1) victim.extinguish();
+//        }
+//
+//        if(EnchantmentRegistry.dragging.isEnabled()) {
+//            float draggingPower = properties.getDraggingPower();
+//            if(draggingPower > 0) {
+//                double velocityMultiplier = -0.6F * draggingPower / MathHelper.sqrt(arrow.motionX * arrow.motionX + arrow.motionZ * arrow.motionZ);
+//                victim.addVelocity(arrow.motionX * velocityMultiplier, 0.1, arrow.motionZ * velocityMultiplier);
+//                victim.velocityChanged = true;
+//            }
+//        }
+//
+//        if(EnchantmentRegistry.strafe.isEnabled()) {
+//            if(properties.getArrowResetsIFrames()) {
+//                victim.hurtResistantTime = 0;
+//            }
+//        }
+//    }
+
+//    private static int getFireSeconds(int tier) {
+//        switch(tier) {
+//            case 1:
+//                return 2;
+//            case 2:
+//                return 15;
+//            case 3:
+//                return 30;
+//        }
+//        return 0;
+//    }
+//
+//    public static void setArrowEnchantmentsFromStack(ItemStack bow, EntityEnchantableFireBall arrow, IArrowProperties properties) {
+//        if(EnchantmentRegistry.powerless.isEnabled()) {
+//            int powerlessLevel = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.powerless, bow);
+//            if(powerlessLevel > 0) {
+//                arrow.setDamage((int)(arrow.getDamage() - 0.5D - powerlessLevel * 0.5D));
+//            }
+//        }
+//
+//        if(EnchantmentRegistry.advancedPower.isEnabled()) {
+//            int advPowerLevel = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.advancedPower, bow);
+//            if(advPowerLevel > 0) {
+//                arrow.setDamage((int)(arrow.getDamage() + 1.25D + (double)advPowerLevel * 0.75D));
+//            }
+//        }
+//
+//        if(EnchantmentRegistry.advancedPunch.isEnabled()) {
+//            int advPunchLevel = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.advancedPunch, bow);
+//            if(advPunchLevel > 0) {
+//                arrow.setKnockbackStrength(1 + advPunchLevel * 2);
+//            }
+//        }
+//
+//        if(EnchantmentRegistry.runeArrowPiercing.isEnabled()) {
+//            int runeArrowPiercingLevel = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.runeArrowPiercing, bow);
+//            if(runeArrowPiercingLevel > 0) {
+//                properties.setArmorPiercingLevel(runeArrowPiercingLevel);
+//            }
+//        }
+//
+//        if(EnchantmentRegistry.dragging.isEnabled()) {
+//            int draggingLevel = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.dragging, bow);
+//            if(draggingLevel > 0) {
+//                properties.setDraggingPower(1.25F + draggingLevel * 1.75F);
+//            }
+//        }
+//
+//        if(EnchantmentRegistry.strafe.isEnabled()) {
+//            int levelStrafe = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.strafe, bow);
+//            if(RANDOM.nextFloat() < 0.125F * levelStrafe) {
+//                properties.setArrowResetsIFrames(true);
+//            }
+//        }
+//
+//        if(EnchantmentRegistry.lesserFlame.isEnabled()) {
+//            int levelLessFlame = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.lesserFlame, bow);
+//            if(levelLessFlame > 0) {
+//                arrow.setFire(50);
+//                properties.setFlameLevel(1);
+//            }
+//        }
+//
+//        if(EnchantmentRegistry.advancedFlame.isEnabled()) {
+//            int levelAdvFlame = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.advancedFlame, bow);
+//            if(levelAdvFlame > 0) {
+//                arrow.setFire(200);
+//                properties.setFlameLevel(2);
+//            }
+//        }
+//
+//        if(EnchantmentRegistry.supremeFlame.isEnabled()) {
+//            int levelSupFlame = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.supremeFlame, bow);
+//            if(levelSupFlame > 0) {
+//                arrow.setFire(400);
+//                properties.setFlameLevel(3);
+//            }
+//        }
+//
+//        if(EnchantmentRegistry.extinguish.isEnabled()) {
+//            int levelExtinguish = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.extinguish, bow);
+//            if(levelExtinguish > 0) {
+//                arrow.extinguish();
+//                properties.setFlameLevel(-1);
+//            }
+//        }
+//    }
+//
+//    public static void setArrowEnchantmentsFromStack(ItemStack bow, EntityCactusThorn arrow, IArrowProperties properties) {
+//        if(EnchantmentRegistry.powerless.isEnabled()) {
+//            int powerlessLevel = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.powerless, bow);
+//            if(powerlessLevel > 0) {
+//                arrow.setDamage(arrow.getDamage() - 0.5D - powerlessLevel * 0.5D);
+//                if(powerlessLevel > 2 || RANDOM.nextFloat() < powerlessLevel * 0.4F) {
+//                    arrow.setIsCritical(false);
+//                }
+//            }
+//        }
+//
+//        if(EnchantmentRegistry.advancedPower.isEnabled()) {
+//            int advPowerLevel = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.advancedPower, bow);
+//            if(advPowerLevel > 0) {
+//                arrow.setDamage(arrow.getDamage() + 0.25D + (double)advPowerLevel * 0.75D);
+//                if(advPowerLevel >= 4 || RANDOM.nextFloat() < advPowerLevel * 0.25F) {
+//                    arrow.setIsCritical(true);
+//                }
+//            }
+//        }
+//
+//        if(EnchantmentRegistry.advancedPunch.isEnabled()) {
+//            int advPunchLevel = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.advancedPunch, bow);
+//            if(advPunchLevel > 0) {
+//                arrow.setKnockbackStrength(1 + advPunchLevel * 2);
+//            }
+//        }
+//
+//        if(EnchantmentRegistry.runeArrowPiercing.isEnabled()) {
+//            int runeArrowPiercingLevel = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.runeArrowPiercing, bow);
+//            if(runeArrowPiercingLevel > 0) {
+//                properties.setArmorPiercingLevel(runeArrowPiercingLevel);
+//            }
+//        }
+//
+//        if(EnchantmentRegistry.dragging.isEnabled()) {
+//            int draggingLevel = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.dragging, bow);
+//            if(draggingLevel > 0) {
+//                properties.setDraggingPower(1.25F + draggingLevel * 1.75F);
+//            }
+//        }
+//
+//        if(EnchantmentRegistry.strafe.isEnabled()) {
+//            int levelStrafe = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.strafe, bow);
+//            if(RANDOM.nextFloat() < 0.125F * levelStrafe) {
+//                properties.setArrowResetsIFrames(true);
+//            }
+//        }
+//
+//        if(EnchantmentRegistry.lesserFlame.isEnabled()) {
+//            int levelLessFlame = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.lesserFlame, bow);
+//            if(levelLessFlame > 0) {
+//                arrow.setFire(50);
+//                properties.setFlameLevel(1);
+//            }
+//        }
+//
+//        if(EnchantmentRegistry.advancedFlame.isEnabled()) {
+//            int levelAdvFlame = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.advancedFlame, bow);
+//            if(levelAdvFlame > 0) {
+//                arrow.setFire(200);
+//                properties.setFlameLevel(2);
+//            }
+//        }
+//
+//        if(EnchantmentRegistry.supremeFlame.isEnabled()) {
+//            int levelSupFlame = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.supremeFlame, bow);
+//            if(levelSupFlame > 0) {
+//                arrow.setFire(400);
+//                properties.setFlameLevel(3);
+//            }
+//        }
+//
+//        if(EnchantmentRegistry.extinguish.isEnabled()) {
+//            int levelExtinguish = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.extinguish, bow);
+//            if(levelExtinguish > 0) {
+//                arrow.extinguish();
+//                properties.setFlameLevel(-1);
+//            }
+//        }
+//    }
+//
+//    public boolean isLauncherAmmo(Object object){
+//        return (object instanceof  EntityCactusThorn || object instanceof EntityDeathCoil || object instanceof EntityEnchantableFireBall);
+//    }
+}

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/compat/somanyenchantments/LauncherAmmoHandler.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/compat/somanyenchantments/LauncherAmmoHandler.java
@@ -1,5 +1,6 @@
 package com.Fishmod.mod_LavaCow.compat.somanyenchantments;
 
+import com.Fishmod.mod_LavaCow.client.Modconfig;
 import com.Fishmod.mod_LavaCow.entities.projectiles.EntityCactusThorn;
 import com.Fishmod.mod_LavaCow.entities.projectiles.EntityDeathCoil;
 import com.Fishmod.mod_LavaCow.entities.projectiles.EntityEnchantableFireBall;
@@ -111,6 +112,7 @@ public class LauncherAmmoHandler {
         IArrowProperties properties = arrow.getCapability(ArrowPropertiesProvider.ARROWPROPERTIES_CAP, null);
         if(properties == null) return;
 
+        if(!(Modconfig.SME_Compat_Special)) return;
         if(EnchantmentRegistry.runeArrowPiercing.isEnabled()) {
             int pierceLevel = properties.getArmorPiercingLevel();
             if(pierceLevel > 0) {
@@ -154,6 +156,7 @@ public class LauncherAmmoHandler {
             }
         }
 
+        if(!(Modconfig.SME_Compat_Special)) return;
         if(EnchantmentRegistry.strafe.isEnabled()) {
             if(properties.getArrowResetsIFrames()) {
                 victim.hurtResistantTime = 0;

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/compat/somanyenchantments/LauncherAmmoHandler.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/compat/somanyenchantments/LauncherAmmoHandler.java
@@ -35,9 +35,7 @@ public class LauncherAmmoHandler {
     // EntityPiranhaLauncher extends EntityEnchantableFireBall extends EntityFireball
     // EntityEnchantableFireBall extends EntityFireball
     // Safe to assume EntityCactusThorn, EntityDeathCoil, and EntityEnchantableFireBall are only ever Fish Mod
-
-    // Arrow -> Thorn 1/5
-    // 1.25 + 0.75lvl -> (5/2)(3/5) (3/2)(1/5) -> 3/2  3/10
+    // Power tiers handled in ItemPiranhaLauncher to be the least headache
 
     private static final ResourceLocation ARROWPROPERTIES_CAP_RESOURCE = new ResourceLocation(SoManyEnchantments.MODID + ":arrow_capabilities");
 
@@ -176,8 +174,6 @@ public class LauncherAmmoHandler {
     }
 
     // This is ridiculous
-    // Arrow -> Thorn 1/5
-    // Other -> 2.5x Flat + 1.5xlvl
     public static void setArrowEnchantmentsFromStack(ItemStack bow, Entity arrow, IArrowProperties properties) {
         boolean isDeathCoil = arrow instanceof EntityDeathCoil;
         boolean ispiranha = arrow instanceof EntityPiranhaLauncher;
@@ -189,30 +185,20 @@ public class LauncherAmmoHandler {
         if(EnchantmentRegistry.powerless.isEnabled()) {
             int powerlessLevel = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.powerless, bow);
             if(powerlessLevel > 0) {
-                if(isDeathCoil) ((EntityDeathCoil)arrow).setDamage((int)(((EntityDeathCoil)arrow).getDamage() / (1.25D + (double)powerlessLevel * 0.25D)));
-                else if(ispiranha) ((EntityPiranhaLauncher)arrow).setDamage((int)(((EntityPiranhaLauncher)arrow).getDamage() / (1.25D + (double)powerlessLevel * 0.25D)));
-                else if(isFireBall) ((EntityEnchantableFireBall)arrow).setDamage((int)(((EntityEnchantableFireBall)arrow).getDamage() / (1.25D + (double)powerlessLevel * 0.25D)));
-                else {
-                    ((EntityCactusThorn)arrow).setDamage(((EntityCactusThorn)arrow).getDamage() - (0.1D - (double)powerlessLevel * 0.1D));
+                if(isCactusThorn)
                     if (powerlessLevel > 2 || RANDOM.nextFloat() < powerlessLevel * 0.4F) {
-                        ((EntityCactusThorn)arrow).setIsCritical(false);
+                        ((EntityCactusThorn) arrow).setIsCritical(false);
                     }
-                }
             }
         }
 
         if(EnchantmentRegistry.advancedPower.isEnabled()) {
             int advPowerLevel = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.advancedPower, bow);
             if(advPowerLevel > 0) {
-                if(isDeathCoil) ((EntityDeathCoil)arrow).setDamage((int)(((EntityDeathCoil)arrow).getDamage() * (1.875D + (double)advPowerLevel * 0.225D)));
-                else if(ispiranha) ((EntityPiranhaLauncher)arrow).setDamage((int)(((EntityPiranhaLauncher)arrow).getDamage() * (1.875D + (double)advPowerLevel * 0.225D)));
-                else if(isFireBall) ((EntityEnchantableFireBall)arrow).setDamage((int)(((EntityEnchantableFireBall)arrow).getDamage() * (1.875D + (double)advPowerLevel * 0.225D)));
-                else {
-                    ((EntityCactusThorn)arrow).setDamage(((EntityCactusThorn)arrow).getDamage() + (0.05D + (double)advPowerLevel * 0.15D));
-                    if(advPowerLevel >= 4 || RANDOM.nextFloat() < advPowerLevel * 0.25F) {
-                        ((EntityCactusThorn)arrow).setIsCritical(true);
+                if(isCactusThorn)
+                    if (advPowerLevel >= 4 || RANDOM.nextFloat() < advPowerLevel * 0.25F) {
+                        ((EntityCactusThorn) arrow).setIsCritical(true);
                     }
-                }
             }
         }
 

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/compat/somanyenchantments/SoManyEnchantmentsCompat.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/compat/somanyenchantments/SoManyEnchantmentsCompat.java
@@ -12,8 +12,14 @@ public class SoManyEnchantmentsCompat {
         MinecraftForge.EVENT_BUS.register(new EnchantmentSplitshotHandler());
     }
 
+    public static int getPowerlessLevel(ItemStack itemStack){
+        return EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.powerless, itemStack);
+    }
+    public static int getAdvancedPowerLevel(ItemStack itemStack){
+        return EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.advancedPower, itemStack);
+    }
+
     public static int getAdvancedMendingLevel(ItemStack itemStack){
-        if(!(EnchantmentRegistry.advancedMending.isEnabled())) return 0;
         return EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.advancedMending, itemStack);
     }
     public static int roundAverage(float value) {

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/compat/somanyenchantments/SoManyEnchantmentsCompat.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/compat/somanyenchantments/SoManyEnchantmentsCompat.java
@@ -1,17 +1,80 @@
 package com.Fishmod.mod_LavaCow.compat.somanyenchantments;
 
+import com.Fishmod.mod_LavaCow.entities.projectiles.EntityCactusThorn;
+import com.Fishmod.mod_LavaCow.item.ItemPiranhaLauncher;
+import com.shultrea.rin.properties.ArrowPropertiesProvider;
+import com.shultrea.rin.properties.ArrowPropertiesHandler;
+import com.shultrea.rin.properties.IArrowProperties;
 import com.shultrea.rin.registry.EnchantmentRegistry;
 import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.EntityJoinWorldEvent;
+import net.minecraftforge.fml.common.eventhandler.EventPriority;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 public class SoManyEnchantmentsCompat {
 
-    public static int getAdvancedMendingLevel(ItemStack itemStack){
-        return EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.advancedMending, itemStack);
+    public static void init(){
+        // Currently a disaster
+//        MinecraftForge.EVENT_BUS.register(LauncherAmmoHandler.class);
     }
 
+    public static int getAdvancedMendingLevel(ItemStack itemStack){
+        if(!(EnchantmentRegistry.advancedMending.isEnabled())) return 0;
+        return EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.advancedMending, itemStack);
+    }
     public static int roundAverage(float value) {
         double floor = Math.floor(value);
         return (int) floor + (Math.random() < value - floor ? 1 : 0);
+    }
+
+    // EntityCactusThorn extends EntityArrow
+    // EntityDeathCoil extends EntityWitherSkull extends EntityFireball
+    // EntityPiranhaLauncher extends EntityEnchantableFireBall extends EntityFireball
+    // EntityEnchantableFireBall extends EntityFireball
+
+    /*
+    * SME auto does handling on EntityJoinWorldEvent only on instances of EntityArrow
+    * Therefore must get the modded enchant levels and return their ratio compared to vanilla
+    * Also have to consider SME Arrow properties applying to EntityCactusThorn, but not the other three ammos
+    */
+    public static int getSMEPowerLevel(ItemStack bow){
+        if(EnchantmentRegistry.powerless.isEnabled()) {
+            int powerlessLevel = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.powerless, bow);
+            if(powerlessLevel > 0) { return -1 * powerlessLevel; } // Curse, equal to -1 Power per level
+        }
+        else if(EnchantmentRegistry.advancedPower.isEnabled()) {
+            int advPowerLevel = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.advancedPower, bow);
+            if(advPowerLevel > 0) { return (int)(advPowerLevel * 5 / 3); } // 5/3 Power at level V, gets truncated
+        }
+        return 0;
+    }
+    public static int getSMEPunchLevel(ItemStack bow){
+        if(EnchantmentRegistry.advancedPunch.isEnabled()) {
+            int advPunchLevel = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.advancedPunch, bow);
+            if (advPunchLevel > 0) { return (1 + advPunchLevel * 2); }
+        }
+        // Would be funny but not possible to do SME Dragging
+        return 0;
+    }
+    public static int getSMEFlameLevel(ItemStack bow){
+        if(EnchantmentRegistry.lesserFlame.isEnabled()) {
+            int levelLessFlame = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.lesserFlame, bow);
+            if(levelLessFlame > 0) { return levelLessFlame; } // Technically should be 0.5, but using ints
+        }
+        else if(EnchantmentRegistry.advancedFlame.isEnabled()) {
+            int levelAdvFlame = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.advancedFlame, bow);
+            if(levelAdvFlame > 0) { return 2 * levelAdvFlame; }
+        }
+        else if(EnchantmentRegistry.supremeFlame.isEnabled()) {
+            int levelSupFlame = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.supremeFlame, bow);
+            if(levelSupFlame > 0) { return 4 * levelSupFlame; }
+        }
+        else if(EnchantmentRegistry.extinguish.isEnabled()) {
+            if(EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.extinguish, bow) > 0) { return 0; }
+        }
+        return 0;
     }
 }

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/compat/somanyenchantments/SoManyEnchantmentsCompat.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/compat/somanyenchantments/SoManyEnchantmentsCompat.java
@@ -13,13 +13,16 @@ public class SoManyEnchantmentsCompat {
     }
 
     public static int getPowerlessLevel(ItemStack itemStack){
+        if(!(EnchantmentRegistry.powerless.isEnabled())) return 0;
         return EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.powerless, itemStack);
     }
     public static int getAdvancedPowerLevel(ItemStack itemStack){
+        if(!(EnchantmentRegistry.advancedPower.isEnabled())) return 0;
         return EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.advancedPower, itemStack);
     }
 
     public static int getAdvancedMendingLevel(ItemStack itemStack){
+        if(!(EnchantmentRegistry.advancedMending.isEnabled())) return 0;
         return EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.advancedMending, itemStack);
     }
     public static int roundAverage(float value) {

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/compat/somanyenchantments/SoManyEnchantmentsCompat.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/compat/somanyenchantments/SoManyEnchantmentsCompat.java
@@ -1,24 +1,15 @@
 package com.Fishmod.mod_LavaCow.compat.somanyenchantments;
 
-import com.Fishmod.mod_LavaCow.entities.projectiles.EntityCactusThorn;
-import com.Fishmod.mod_LavaCow.item.ItemPiranhaLauncher;
-import com.shultrea.rin.properties.ArrowPropertiesProvider;
-import com.shultrea.rin.properties.ArrowPropertiesHandler;
-import com.shultrea.rin.properties.IArrowProperties;
 import com.shultrea.rin.registry.EnchantmentRegistry;
 import net.minecraft.enchantment.EnchantmentHelper;
-import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.event.entity.EntityJoinWorldEvent;
-import net.minecraftforge.fml.common.eventhandler.EventPriority;
-import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 public class SoManyEnchantmentsCompat {
 
     public static void init(){
-        // Currently a disaster
-//        MinecraftForge.EVENT_BUS.register(LauncherAmmoHandler.class);
+        MinecraftForge.EVENT_BUS.register(new LauncherAmmoHandler());
+        MinecraftForge.EVENT_BUS.register(new EnchantmentSplitshotHandler());
     }
 
     public static int getAdvancedMendingLevel(ItemStack itemStack){
@@ -28,53 +19,5 @@ public class SoManyEnchantmentsCompat {
     public static int roundAverage(float value) {
         double floor = Math.floor(value);
         return (int) floor + (Math.random() < value - floor ? 1 : 0);
-    }
-
-    // EntityCactusThorn extends EntityArrow
-    // EntityDeathCoil extends EntityWitherSkull extends EntityFireball
-    // EntityPiranhaLauncher extends EntityEnchantableFireBall extends EntityFireball
-    // EntityEnchantableFireBall extends EntityFireball
-
-    /*
-    * SME auto does handling on EntityJoinWorldEvent only on instances of EntityArrow
-    * Therefore must get the modded enchant levels and return their ratio compared to vanilla
-    * Also have to consider SME Arrow properties applying to EntityCactusThorn, but not the other three ammos
-    */
-    public static int getSMEPowerLevel(ItemStack bow){
-        if(EnchantmentRegistry.powerless.isEnabled()) {
-            int powerlessLevel = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.powerless, bow);
-            if(powerlessLevel > 0) { return -1 * powerlessLevel; } // Curse, equal to -1 Power per level
-        }
-        else if(EnchantmentRegistry.advancedPower.isEnabled()) {
-            int advPowerLevel = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.advancedPower, bow);
-            if(advPowerLevel > 0) { return (int)(advPowerLevel * 5 / 3); } // 5/3 Power at level V, gets truncated
-        }
-        return 0;
-    }
-    public static int getSMEPunchLevel(ItemStack bow){
-        if(EnchantmentRegistry.advancedPunch.isEnabled()) {
-            int advPunchLevel = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.advancedPunch, bow);
-            if (advPunchLevel > 0) { return (1 + advPunchLevel * 2); }
-        }
-        // Would be funny but not possible to do SME Dragging
-        return 0;
-    }
-    public static int getSMEFlameLevel(ItemStack bow){
-        if(EnchantmentRegistry.lesserFlame.isEnabled()) {
-            int levelLessFlame = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.lesserFlame, bow);
-            if(levelLessFlame > 0) { return levelLessFlame; } // Technically should be 0.5, but using ints
-        }
-        else if(EnchantmentRegistry.advancedFlame.isEnabled()) {
-            int levelAdvFlame = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.advancedFlame, bow);
-            if(levelAdvFlame > 0) { return 2 * levelAdvFlame; }
-        }
-        else if(EnchantmentRegistry.supremeFlame.isEnabled()) {
-            int levelSupFlame = EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.supremeFlame, bow);
-            if(levelSupFlame > 0) { return 4 * levelSupFlame; }
-        }
-        else if(EnchantmentRegistry.extinguish.isEnabled()) {
-            if(EnchantmentHelper.getEnchantmentLevel(EnchantmentRegistry.extinguish, bow) > 0) { return 0; }
-        }
-        return 0;
     }
 }

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/enchantment/EnchantmentCriticalBoost.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/enchantment/EnchantmentCriticalBoost.java
@@ -65,11 +65,6 @@ public class EnchantmentCriticalBoost extends Enchantment {
     }
 	
 	@Override
-	public void onEntityDamaged(EntityLivingBase user, Entity target, int level) {
-		user.heal((float)user.getEntityAttribute(SharedMonsterAttributes.ATTACK_DAMAGE).getAttributeValue() * (float)level * 0.05F);
-	}
-	
-	@Override
 	public boolean canApplyTogether(Enchantment enchant) {
 		return !(enchant instanceof EnchantmentDamage);
 	}

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/entities/EntitySkeletonKing.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/entities/EntitySkeletonKing.java
@@ -220,8 +220,10 @@ public class EntitySkeletonKing extends EntityMob implements IAggressive {
             for (EntityLivingBase entitylivingbase : this.world.getEntitiesWithinAABB(EntityLivingBase.class, new AxisAlignedBB(d0, d1, d2, d0, d1, d2).grow(1.5D))) {
                 if (!this.isEntityEqual(entitylivingbase) && !this.isOnSameTeam(entitylivingbase)) {
                     entitylivingbase.attackEntityFrom(DamageSource.causeMobDamage(this), (float) this.getAttributeMap().getAttributeInstance(SharedMonsterAttributes.ATTACK_DAMAGE).getAttributeValue());
-                    entitylivingbase.addPotionEffect(new PotionEffect(ModMobEffects.FRAGILE_KING, 20 * 20, 3));
-                    entitylivingbase.addPotionEffect(new PotionEffect(MobEffects.WITHER, 15 * 20, 2));
+                    if(!(this.world.isRemote)) {
+                        entitylivingbase.addPotionEffect(new PotionEffect(ModMobEffects.FRAGILE_KING, 20 * 20, 3));
+                        entitylivingbase.addPotionEffect(new PotionEffect(MobEffects.WITHER, 15 * 20, 2));
+                    }
                     if (entitylivingbase instanceof EntityPlayer) ((EntityPlayer) entitylivingbase).disableShield(true);
 
                     if (this.isAngered()) {

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/item/ItemCrown.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/item/ItemCrown.java
@@ -27,6 +27,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.EnumDifficulty;
 import net.minecraft.world.World;
+import net.minecraft.world.biome.Biome;
 import net.minecraftforge.common.BiomeDictionary;
 import net.minecraftforge.common.BiomeDictionary.Type;
 import net.minecraftforge.fml.relauncher.Side;
@@ -54,9 +55,7 @@ public class ItemCrown extends ItemFishCustom {
         if(player.getHeldItem(hand).getMetadata() == 1 && Modconfig.pSpawnRate_SkeletonKing
         		&& worldIn.getBlockState(pos).getBlock().equals(Blocks.SKULL)
         		&& !(worldIn.getDifficulty() == EnumDifficulty.PEACEFUL)
-        		&& BiomeDictionary.hasType(worldIn.getBiome(pos), Type.HOT)
-        		&& BiomeDictionary.hasType(worldIn.getBiome(pos), Type.DRY)
-        		&& BiomeDictionary.hasType(worldIn.getBiome(pos), Type.SANDY))
+				&& isValidCrownBiome(worldIn.getBiome(pos)))
         {
         	TileEntity tileentity = worldIn.getTileEntity(pos);
         	
@@ -111,4 +110,19 @@ public class ItemCrown extends ItemFishCustom {
             }
         }
     }
+
+	/*
+	*	Option to modify the biome tag list for custom biomes
+	 */
+	public boolean isValidCrownBiome(Biome biome){
+		for(String tag: Modconfig.SkeletonKing_Biome_Allowlist){
+			if(BiomeDictionary.hasType(biome, Type.getType(tag))){
+				if(!(Modconfig.SkeletonKing_Biome_Need_All)) return true;
+			}
+			else{
+				if(Modconfig.SkeletonKing_Biome_Need_All) return false;
+			}
+		}
+		return Modconfig.SkeletonKing_Biome_Need_All;
+	}
 }

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/item/ItemFishCustomWeapon.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/item/ItemFishCustomWeapon.java
@@ -6,7 +6,7 @@ import java.util.Set;
 import javax.annotation.Nullable;
 
 import com.Fishmod.mod_LavaCow.compat.CompatUtilBridge;
-import com.Fishmod.mod_LavaCow.compat.rlcombat.RLCombatCompat;
+import com.Fishmod.mod_LavaCow.entities.tameable.EntitySummonedZombie;
 import com.Fishmod.mod_LavaCow.mod_LavaCow;
 import com.Fishmod.mod_LavaCow.client.Modconfig;
 import com.Fishmod.mod_LavaCow.entities.EntityMummy;
@@ -281,6 +281,7 @@ public class ItemFishCustomWeapon extends ItemSword {
                 nbttagcompound.setInteger("corrosive", corrosive);
                 entity.readEntityFromNBT(nbttagcompound);
                 entity.setLimitedLife(Modconfig.LilSludge_Lifespan * 20);
+                entity.setHealth(entity.getMaxHealth());
                 entity.setSkin((fire_aspect > 0) ? 1 : 0);
 
                 if (playerIn.world instanceof World) {
@@ -327,6 +328,7 @@ public class ItemFishCustomWeapon extends ItemSword {
                 nbttagcompound.setInteger("corrosive", corrosive);
                 entity.readEntityFromNBT(nbttagcompound);
                 entity.setLimitedLife(Modconfig.Amber_Scarab_Lifespan * 20);
+                entity.setHealth(entity.getMaxHealth());
 
                 if (playerIn.world instanceof World) {
                     for (int j = 0; j < 24; ++j) {
@@ -445,109 +447,14 @@ public class ItemFishCustomWeapon extends ItemSword {
             for (int i = 0; i < 4; ++i) {
                 NBTTagCompound nbttagcompound = new NBTTagCompound();
                 BlockPos blockpos = (new BlockPos(playerIn)).add(-4 + Item.itemRand.nextInt(8), 0, -4 + Item.itemRand.nextInt(8));
-                if (worldIn.rand.nextFloat() < 0.15F) {
-                    if (BiomeDictionary.hasType(playerIn.getEntityWorld().getBiome(playerIn.getPosition()), Type.DRY)) {
-                        EntityMummy entity = new EntityMummy(worldIn);
-                        entity.moveToBlockPosAndAngles(blockpos, 0.0F, 0.0F);
-                        entity.onInitialSpawn(worldIn.getDifficultyForLocation(blockpos), (IEntityLivingData) null);
-                        entity.setOwnerId(playerIn.getUniqueID());
-                        entity.setCanPickUpLoot(false);
-                        entity.setTamed(true);
-                        nbttagcompound.setInteger("fire_aspect", fire_aspect);
-                        nbttagcompound.setInteger("sharpness", sharpness);
-                        nbttagcompound.setInteger("knockback", knockback);
-                        nbttagcompound.setInteger("bane_of_arthropods", bane_of_arthropods);
-                        nbttagcompound.setInteger("smite", smite);
-                        nbttagcompound.setInteger("unbreaking", unbreaking);
-                        nbttagcompound.setInteger("lifesteal", lifesteal);
-                        nbttagcompound.setInteger("poisonous", poisonous);
-                        nbttagcompound.setInteger("corrosive", corrosive);
-                        entity.readEntityFromNBT(nbttagcompound);
-                        entity.setLimitedLife(Modconfig.Unburied_Lifespan * 20);
-
-                        if (playerIn.world instanceof World) {
-                            for (int j = 0; j < 24; ++j) {
-                                double d0 = entity.posX + (double) (entity.world.rand.nextFloat() * entity.width * 2.0F) - (double) entity.width;
-                                double d1 = entity.posY + (double) (entity.world.rand.nextFloat() * entity.height);
-                                double d2 = entity.posZ + (double) (entity.world.rand.nextFloat() * entity.width * 2.0F) - (double) entity.width;
-                                mod_LavaCow.NETWORK_WRAPPER.sendToAll(new PacketParticle(fire_aspect > 0 ? EnumParticleTypes.FLAME : EnumParticleTypes.SMOKE_LARGE, d0, d1, d2));
-                            }
-                        }
-
-                        if (!worldIn.isRemote) {
-                            worldIn.spawnEntity(entity);
-                        }
-
-                        worldIn.setEntityState(entity, (byte) 32);
-                    } else if (BiomeDictionary.hasType(playerIn.getEntityWorld().getBiome(playerIn.getPosition()), Type.COLD)) {
-                        EntityZombieFrozen entity = new EntityZombieFrozen(worldIn);
-                        entity.moveToBlockPosAndAngles(blockpos, 0.0F, 0.0F);
-                        entity.onInitialSpawn(worldIn.getDifficultyForLocation(blockpos), (IEntityLivingData) null);
-                        entity.setOwnerId(playerIn.getUniqueID());
-                        entity.setCanPickUpLoot(false);
-                        entity.setTamed(true);
-                        nbttagcompound.setInteger("fire_aspect", fire_aspect);
-                        nbttagcompound.setInteger("sharpness", sharpness);
-                        nbttagcompound.setInteger("knockback", knockback);
-                        nbttagcompound.setInteger("bane_of_arthropods", bane_of_arthropods);
-                        nbttagcompound.setInteger("smite", smite);
-                        nbttagcompound.setInteger("unbreaking", unbreaking);
-                        nbttagcompound.setInteger("lifesteal", lifesteal);
-                        nbttagcompound.setInteger("poisonous", poisonous);
-                        nbttagcompound.setInteger("corrosive", corrosive);
-                        entity.readEntityFromNBT(nbttagcompound);
-                        entity.setLimitedLife(Modconfig.Unburied_Lifespan * 20);
-
-                        if (playerIn.world instanceof World) {
-                            for (int j = 0; j < 24; ++j) {
-                                double d0 = entity.posX + (double) (entity.world.rand.nextFloat() * entity.width * 2.0F) - (double) entity.width;
-                                double d1 = entity.posY + (double) (entity.world.rand.nextFloat() * entity.height);
-                                double d2 = entity.posZ + (double) (entity.world.rand.nextFloat() * entity.width * 2.0F) - (double) entity.width;
-                                mod_LavaCow.NETWORK_WRAPPER.sendToAll(new PacketParticle(fire_aspect > 0 ? EnumParticleTypes.FLAME : EnumParticleTypes.SMOKE_LARGE, d0, d1, d2));
-                            }
-                        }
-
-                        if (!worldIn.isRemote) {
-                            worldIn.spawnEntity(entity);
-                        }
-
-                        worldIn.setEntityState(entity, (byte) 32);
-                    } else if (BiomeDictionary.hasType(playerIn.getEntityWorld().getBiome(playerIn.getPosition()), Type.WET)) {
-                        EntityZombieMushroom entity = new EntityZombieMushroom(worldIn);
-                        entity.moveToBlockPosAndAngles(blockpos, 0.0F, 0.0F);
-                        entity.onInitialSpawn(worldIn.getDifficultyForLocation(blockpos), (IEntityLivingData) null);
-                        entity.setOwnerId(playerIn.getUniqueID());
-                        entity.setCanPickUpLoot(false);
-                        entity.setTamed(true);
-                        nbttagcompound.setInteger("fire_aspect", fire_aspect);
-                        nbttagcompound.setInteger("sharpness", sharpness);
-                        nbttagcompound.setInteger("knockback", knockback);
-                        nbttagcompound.setInteger("bane_of_arthropods", bane_of_arthropods);
-                        nbttagcompound.setInteger("smite", smite);
-                        nbttagcompound.setInteger("unbreaking", unbreaking);
-                        nbttagcompound.setInteger("lifesteal", lifesteal);
-                        nbttagcompound.setInteger("poisonous", poisonous);
-                        nbttagcompound.setInteger("corrosive", corrosive);
-                        entity.readEntityFromNBT(nbttagcompound);
-                        entity.setLimitedLife(Modconfig.Unburied_Lifespan * 20);
-
-                        if (playerIn.world instanceof World) {
-                            for (int j = 0; j < 24; ++j) {
-                                double d0 = entity.posX + (double) (entity.world.rand.nextFloat() * entity.width * 2.0F) - (double) entity.width;
-                                double d1 = entity.posY + (double) (entity.world.rand.nextFloat() * entity.height);
-                                double d2 = entity.posZ + (double) (entity.world.rand.nextFloat() * entity.width * 2.0F) - (double) entity.width;
-                                mod_LavaCow.NETWORK_WRAPPER.sendToAll(new PacketParticle(fire_aspect > 0 ? EnumParticleTypes.FLAME : EnumParticleTypes.SMOKE_LARGE, d0, d1, d2));
-                            }
-                        }
-
-                        if (!worldIn.isRemote) {
-                            worldIn.spawnEntity(entity);
-                        }
-
-                        worldIn.setEntityState(entity, (byte) 32);
-                    }
-                } else {
-                    EntityUnburied entity = new EntityUnburied(worldIn);
+                if ((i==0) || worldIn.rand.nextFloat() < 0.15F) {
+                    EntitySummonedZombie entity = new EntityUnburied(worldIn);
+                    if(BiomeDictionary.hasType(playerIn.getEntityWorld().getBiome(playerIn.getPosition()), Type.DRY))
+                        entity = new EntityMummy(worldIn);
+                    else if(BiomeDictionary.hasType(playerIn.getEntityWorld().getBiome(playerIn.getPosition()), Type.COLD))
+                        entity = new EntityZombieFrozen(worldIn);
+                    else if(BiomeDictionary.hasType(playerIn.getEntityWorld().getBiome(playerIn.getPosition()), Type.WET))
+                        entity = new EntityZombieMushroom(worldIn);
                     entity.moveToBlockPosAndAngles(blockpos, 0.0F, 0.0F);
                     entity.onInitialSpawn(worldIn.getDifficultyForLocation(blockpos), (IEntityLivingData) null);
                     entity.setOwnerId(playerIn.getUniqueID());
@@ -564,6 +471,7 @@ public class ItemFishCustomWeapon extends ItemSword {
                     nbttagcompound.setInteger("corrosive", corrosive);
                     entity.readEntityFromNBT(nbttagcompound);
                     entity.setLimitedLife(Modconfig.Unburied_Lifespan * 20);
+                    entity.setHealth(entity.getMaxHealth());
 
                     if (playerIn.world instanceof World) {
                         for (int j = 0; j < 24; ++j) {

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/item/ItemFishCustomWeapon.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/item/ItemFishCustomWeapon.java
@@ -425,7 +425,7 @@ public class ItemFishCustomWeapon extends ItemSword {
             return new ActionResult<ItemStack>(EnumActionResult.SUCCESS, playerIn.getHeldItem(handIn));
         }
 
-        if (playerIn.getHeldItem(handIn).getItem() == FishItems.BEAST_CLAW && playerIn.onGround) {
+        if (playerIn.getHeldItem(handIn).getItem() == FishItems.BEAST_CLAW && playerIn.onGround && (!(Modconfig.BeastClaw_Needs_Sneak) || playerIn.isSneaking())) {
             Vec3d lookVec = playerIn.getLookVec();
 
             if (playerIn.getHeldItemOffhand().getItem() == FishItems.BEAST_CLAW && playerIn.getHeldItemMainhand().getItem() == FishItems.BEAST_CLAW) {

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/item/ItemMoltenAxe.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/item/ItemMoltenAxe.java
@@ -40,7 +40,7 @@ public class ItemMoltenAxe extends ItemAxe {
 		super.hitEntity(stack, target, attacker);
 		
 		// Stacks with Fire Aspect
-		target.setFire(8 + 4 * EnchantmentHelper.getEnchantmentLevel(Enchantments.FIRE_ASPECT, attacker.getHeldItem(attacker.getActiveHand())));
+		target.setFire(8 + 4 * EnchantmentHelper.getFireAspectModifier(attacker));
         return true;
     }
 	

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/item/ItemPiranhaLauncher.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/item/ItemPiranhaLauncher.java
@@ -128,8 +128,7 @@ public class ItemPiranhaLauncher extends ItemBow {
 					 /*
 					  * SME Compat Info
 					  * SME auto does handling on EntityJoinWorldEvent only on instances of EntityArrow
-					  * Therefore apply SME "ArrowProperties" on all the ammos
-					  * Fixes OP Thorn Gun and other launchers get not boosts
+					  * Compat handling has to be done after this original handling
 					  */
 					 
 			         int power_lvl = EnchantmentHelper.getEnchantmentLevel(Enchantments.POWER, stack);

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/item/ItemPiranhaLauncher.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/item/ItemPiranhaLauncher.java
@@ -3,6 +3,8 @@ package com.Fishmod.mod_LavaCow.item;
 import java.util.List;
 import javax.annotation.Nullable;
 
+import com.Fishmod.mod_LavaCow.compat.CompatUtilBridge;
+import com.Fishmod.mod_LavaCow.compat.somanyenchantments.SoManyEnchantmentsCompat;
 import com.Fishmod.mod_LavaCow.mod_LavaCow;
 import com.Fishmod.mod_LavaCow.entities.projectiles.EntityCactusThorn;
 import com.Fishmod.mod_LavaCow.entities.projectiles.EntityDeathCoil;
@@ -134,6 +136,13 @@ public class ItemPiranhaLauncher extends ItemBow {
 			         int power_lvl = EnchantmentHelper.getEnchantmentLevel(Enchantments.POWER, stack);
 			         int punch_lvl = EnchantmentHelper.getEnchantmentLevel(Enchantments.PUNCH, stack);
 			         int flame_lvl = EnchantmentHelper.getEnchantmentLevel(Enchantments.FLAME, stack);
+
+					 // SME Lesser and Advanced Power here to simplify things
+					 // Allow "creative" stacking, will truncate
+					 if(CompatUtilBridge.isSMELoaded()) {
+						 power_lvl -= SoManyEnchantmentsCompat.getPowerlessLevel(stack);
+						 power_lvl += 5 * SoManyEnchantmentsCompat.getAdvancedPowerLevel(stack) / 3;
+					 }
 			         
 			         if (this.shot.equals(EntityCactusThorn.class)) {
 				        	EntityCactusThorn abstractarrowentity = new EntityCactusThorn(playerIn.world, playerIn);

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/item/ItemPiranhaLauncher.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/item/ItemPiranhaLauncher.java
@@ -124,6 +124,13 @@ public class ItemPiranhaLauncher extends ItemBow {
 	
 		         if (!worldIn.isRemote) {
 					 Vec3d lookVec = playerIn.getLookVec();
+
+					 /*
+					  * SME Compat Info
+					  * SME auto does handling on EntityJoinWorldEvent only on instances of EntityArrow
+					  * Therefore apply SME "ArrowProperties" on all the ammos
+					  * Fixes OP Thorn Gun and other launchers get not boosts
+					  */
 					 
 			         int power_lvl = EnchantmentHelper.getEnchantmentLevel(Enchantments.POWER, stack);
 			         int punch_lvl = EnchantmentHelper.getEnchantmentLevel(Enchantments.PUNCH, stack);

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/item/ItemSoulforgedAxe.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/item/ItemSoulforgedAxe.java
@@ -42,8 +42,8 @@ public class ItemSoulforgedAxe extends ItemAxe {
 		super.hitEntity(stack, target, attacker);
 		
 		// Stacks with Fire Aspect
-		target.setFire(10 + 5 * EnchantmentHelper.getEnchantmentLevel(Enchantments.FIRE_ASPECT, attacker.getHeldItem(attacker.getActiveHand())));
-		target.addPotionEffect(new PotionEffect(MobEffects.WITHER, 200 + 100 * EnchantmentHelper.getEnchantmentLevel(Enchantments.FIRE_ASPECT, attacker.getHeldItem(attacker.getActiveHand())), 2));
+		target.setFire(10 + 5 * EnchantmentHelper.getFireAspectModifier(attacker));
+		target.addPotionEffect(new PotionEffect(MobEffects.WITHER, 200 + 100 * EnchantmentHelper.getFireAspectModifier(attacker), 2));
         return true;
     }
 	

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/mod_LavaCow.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/mod_LavaCow.java
@@ -7,6 +7,8 @@ import com.Fishmod.mod_LavaCow.compat.somanyenchantments.SoManyEnchantmentsCompa
 import com.Fishmod.mod_LavaCow.compat.tinkers.ConstructsArmoryCompat;
 import com.Fishmod.mod_LavaCow.compat.tinkers.TinkersCompat;
 import com.Fishmod.mod_LavaCow.compat.tinkers.TinkersCompatClient;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import com.Fishmod.mod_LavaCow.client.Modconfig;
@@ -56,7 +58,7 @@ public class mod_LavaCow {
     @Instance(mod_LavaCow.MODID)
     public static mod_LavaCow INSTANCE;
 
-    public static Logger logger;
+    public static Logger logger = LogManager.getLogger(); // Swapped from setting to event.getModLog(); in preinit
 
     public static SimpleNetworkWrapper NETWORK_WRAPPER;
 
@@ -64,7 +66,6 @@ public class mod_LavaCow {
 
     @EventHandler
     public void preInit(FMLPreInitializationEvent event) {
-        logger = event.getModLog();
         TAB_ITEMS = new CreativeTab(MODID + "_items");
         Modconfig.INSTANCE.loadConfig(event);
         MinecraftForge.EVENT_BUS.register(new RegistryHandler());

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/mod_LavaCow.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/mod_LavaCow.java
@@ -3,6 +3,7 @@ package com.Fishmod.mod_LavaCow;
 import com.Fishmod.mod_LavaCow.compat.CompatUtilBridge;
 import com.Fishmod.mod_LavaCow.compat.quark.QuarkCompat;
 import com.Fishmod.mod_LavaCow.compat.rlcombat.RLCombatCompat;
+import com.Fishmod.mod_LavaCow.compat.somanyenchantments.SoManyEnchantmentsCompat;
 import com.Fishmod.mod_LavaCow.compat.tinkers.ConstructsArmoryCompat;
 import com.Fishmod.mod_LavaCow.compat.tinkers.TinkersCompat;
 import com.Fishmod.mod_LavaCow.compat.tinkers.TinkersCompatClient;
@@ -78,6 +79,7 @@ public class mod_LavaCow {
         if(CompatUtilBridge.isConstructsArmoryLoaded()) ConstructsArmoryCompat.init();
         if(CompatUtilBridge.isQuarkLoaded()) QuarkCompat.init();
         if(CompatUtilBridge.isRLCombatLoaded()) MinecraftForge.EVENT_BUS.register(RLCombatCompat.class);
+        if(CompatUtilBridge.isSMELoaded()) SoManyEnchantmentsCompat.init();
 
         PROXY.preInit(event);
 

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/util/ModEventHandler.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/util/ModEventHandler.java
@@ -1165,6 +1165,9 @@ public class ModEventHandler {
 
     @SubscribeEvent
     public void onPCritical(CriticalHitEvent event) {
+        //Handle RLCombat separately using Crit event
+        if(CompatUtilBridge.isRLCombatLoaded()) return;
+
         int CriticalBoostlvl = EnchantmentHelper.getEnchantmentLevel(ModEnchantments.CRITICAL_BOOST, event.getEntityPlayer().getHeldItemMainhand());
 
         if (CriticalBoostlvl != 0 && event.getDamageModifier() > 1.0F) {


### PR DESCRIPTION
Finished RLCombat Compat
* Can redirect sweeping event of Reaper's Scythe to fix offhand calc
* Can redirect critical Hit event of CriticalBoost enchantment to fix offhand calc

Finished So Many Enchantment's Compat
* Most Enchantments with descriptions that make sense for instances of ItemPiranhaLauncher now work (ex Splitshot shooting more and Armor Piercing piercing armor)
* Allowed Tiered Vanilla Enchants to scale Summonable stats and Launcher damage

Ports of Mixins used in RLCraft Dregora
* Added Config to limit Infested Effect parasite spawns
* Added Config to modify King's Crown Summing biome type list, toggle to require all or one, default matches original hardcoded check

Config
* Added Config toggle for Beast Claw requiring sneaking for right click ability (RLCombat QoL)

Changed
* Midnight Mourne will now summon at least one minion instead of having a chance to spawn nothing.

Fixed
* Amber Scarab not dealing bonus Sharpness/Smite/Arthropods Damage nor having Lifesteal bonus
* Mummy/Frigid/Mycosis not dealing bonus Sharpness/Smite/Arthropods Damage nor having Lifesteal bonus
* Summoned minions not spawning with full hp when given an Unbreaking max hp bonus
* Skeleton King applying potion effect debuffs to players on clientside causing possible visual desyncs
* CriticalBoost having a lifesteal effect unlike the 1.16 version