### PR TITLE
[1.12.2] HarvestDropsEvent: Fire harvest check after tool checks

### DIFF
--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/util/ModEventHandler.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/util/ModEventHandler.java
@@ -494,8 +494,8 @@ public class ModEventHandler {
 
     @SubscribeEvent
     public static void onBlockDestroyed(HarvestDropsEvent event) {
-        if (event.getHarvester() != null && event.getState().getBlock().canHarvestBlock(event.getWorld(), event.getPos(), event.getHarvester())) {
-            if (event.getHarvester().getHeldItemMainhand().getItem() == FishItems.MOLTENAXE || event.getHarvester().getHeldItemMainhand().getItem() == FishItems.SOULFORGED_AXE) {
+        if (event.getHarvester() != null && (event.getHarvester().getHeldItemMainhand().getItem() == FishItems.MOLTENAXE || event.getHarvester().getHeldItemMainhand().getItem() == FishItems.SOULFORGED_AXE)) {
+            if (event.getState().getBlock().canHarvestBlock(event.getWorld(), event.getPos(), event.getHarvester())) {
                 List<ItemStack> to_be_removed = new ArrayList<ItemStack>();
                 List<ItemStack> to_be_added = new ArrayList<ItemStack>();
 


### PR DESCRIPTION
This ensures to only run custom drop logic after either a Molten Axe or a Soulforged Axe was detected. Resolves concurrency issues with other tools that have their own block breaking behavior.

Fixes #202