### PR TITLE
[1.12.2] Remove disabling scarecrow head face culling

### DIFF
--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/client/model/block/ModelScarecrowHead_common.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/client/model/block/ModelScarecrowHead_common.java
@@ -48,7 +48,6 @@ public class ModelScarecrowHead_common extends ModelBase {
     @Override
     public void render(Entity entity, float f, float f1, float f2, float f3, float f4, float f5) { 
     	GlStateManager.rotate(180.0F, 0.0F, 0.0F, 1.0F);
-    	GL11.glDisable(GL11.GL_CULL_FACE);
     	this.Head.render(f5);
     }
 


### PR DESCRIPTION
This OpenGL call to disable face culling for rendering scarecrow heads leaked into other rendering (messing up JER chest rendering for example). I couldn't notice any visual differences with and without culling whatsoever, so I decided to simply remove it. Might be a Tabula leftover.