### PR TITLE
[1.12.2] Fix Deathtouched/King's Touch effect bugs

### DIFF
--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/mobeffect/MobEffectFragile.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/mobeffect/MobEffectFragile.java
@@ -1,9 +1,12 @@
 package com.Fishmod.mod_LavaCow.mobeffect;
 
 import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.DamageSource;
 
 public class MobEffectFragile extends MobEffectMod {
+    // TODO: Use custom damage type (for death message)
+    public static final DamageSource FRAGILE_DAMAGE = new DamageSource("wither").setDamageIsAbsolute().setDamageBypassesArmor();
 
 	public MobEffectFragile() {
 		super("fragile", true, 53, 39, 42);
@@ -17,11 +20,14 @@ public class MobEffectFragile extends MobEffectMod {
     
     @Override
     public void performEffect(EntityLivingBase entityLivingBaseIn, int amplifier) {
-        if (entityLivingBaseIn.isNonBoss() && (entityLivingBaseIn.getHealth() / entityLivingBaseIn.getMaxHealth()) < (0.05f * (amplifier + 1))) {
-        	entityLivingBaseIn.attackEntityFrom(DamageSource.WITHER.setDamageIsAbsolute().setDamageBypassesArmor(), entityLivingBaseIn.getMaxHealth());
-        	
-        	// Safety measure in case the above doesn't function correctly
-        	entityLivingBaseIn.setHealth(0.0F);
+        float maxHealth = entityLivingBaseIn.getMaxHealth();
+        if (entityLivingBaseIn.isNonBoss() && (entityLivingBaseIn.getHealth() / maxHealth) < (0.05f * (amplifier + 1))) {
+            if (entityLivingBaseIn instanceof EntityPlayer) {
+                EntityPlayer player = (EntityPlayer) entityLivingBaseIn;
+                if (player.isSpectator() || player.isCreative())
+                    return;
+            }
+        	entityLivingBaseIn.attackEntityFrom(FRAGILE_DAMAGE, maxHealth);
         }
     }
 

--- a/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/mobeffect/MobEffectFragileKing.java
+++ b/Forge1.12.2/src/main/java/com/Fishmod/mod_LavaCow/mobeffect/MobEffectFragileKing.java
@@ -1,7 +1,9 @@
 package com.Fishmod.mod_LavaCow.mobeffect;
 
 import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.util.DamageSource;
+import net.minecraft.entity.player.EntityPlayer;
+
+import static com.Fishmod.mod_LavaCow.mobeffect.MobEffectFragile.FRAGILE_DAMAGE;
 
 public class MobEffectFragileKing extends MobEffectMod {
 
@@ -16,11 +18,14 @@ public class MobEffectFragileKing extends MobEffectMod {
     
     @Override
     public void performEffect(EntityLivingBase entityLivingBaseIn, int amplifier) {
-        if ((entityLivingBaseIn.getHealth() / entityLivingBaseIn.getMaxHealth()) < (0.05f * (amplifier + 1))) {
-        	entityLivingBaseIn.attackEntityFrom(DamageSource.WITHER.setDamageIsAbsolute().setDamageBypassesArmor(), entityLivingBaseIn.getMaxHealth());
-        	
-        	// Safety measure in case the above doesn't function correctly
-        	entityLivingBaseIn.setHealth(0.0F);
+        float maxHealth = entityLivingBaseIn.getMaxHealth();
+        if ((entityLivingBaseIn.getHealth() / maxHealth) < (0.05f * (amplifier + 1))) {
+            if (entityLivingBaseIn instanceof EntityPlayer) {
+                EntityPlayer player = (EntityPlayer) entityLivingBaseIn;
+                if (player.isSpectator() || player.isCreative())
+                    return;
+            }
+            entityLivingBaseIn.attackEntityFrom(FRAGILE_DAMAGE, maxHealth);
         }
     }
 }


### PR DESCRIPTION
The "safety measure" to set entity health to 0 after damaging the entity caused player inventory to be voided if the line was reached (by canceling the death event or using totem of undying).
## Goals
- Fixes issue where dying to the fragile effect(s) with any revive/cheat death mechanic (i.e. totem of undying, other mod mechanics) active would delete the player's inventory (Even graves would not spawn if a grave mod was present)
- Makes creative/spectator players immune to the effect
- Fixes the effect globally mutating wither damage properties

## Non-goals
- Implementing King's Touch attack debuff
- Introducing a new damage type with a custom death message (this requires localization and I don't know what sort of message is desired)